### PR TITLE
further optimize the 8080 instructions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/simcore.h
+++ b/simcore.h
@@ -18,5 +18,14 @@
 #define N_FLAG		2
 #define C_FLAG		1
 
+#define S_SHIFT		7
+#define Z_SHIFT		6
+#define Y_SHIFT		5
+#define H_SHIFT		4
+#define X_SHIFT		3
+#define P_SHIFT		2
+#define N_SHIFT		1
+#define C_SHIFT		0
+
 // possible states of the 8080 CPU
 enum CPUState { Running = 1, Halted = 2 };


### PR DESCRIPTION
Move setting of unused F bits from POP PSW into PUSH PSW, like described in the 8080 datasheet. These bits are now completely ignored in the simulation.

Make t a BYTE.

Change "(x << 8) + y" into "(x << 8) | y".

Use 16-bit arithmetic for 16-bit operations.

Compute carry flags without using conditionals.

Rewrote DAA after looking at a Verilog file for a USSR 8080 clone to see how DAA really works.

The only instructions that use conditional branches are now DAA and the conditional JMPs, CALLs, and RETs.

Checked with ex8080 that I didn't break any instructions.

Add a .gitattributes file. simcore.h was a CRLF file.