### PR TITLE
new register representation

### DIFF
--- a/arduino_8080.ino.8080
+++ b/arduino_8080.ino.8080
@@ -41,10 +41,39 @@ typedef unsigned int  WORD;
 #include "iosim.h"
 #include "config.h"
 
+#if _BYTE_ORDER == _LITTLE_ENDIAN
+struct cpu_reg {
+  union {
+    struct {
+      BYTE l;
+      BYTE h;
+    };
+    WORD w;
+  };
+};
+#elif _BYTE_ORDER == _BIG_ENDIAN
+struct cpu_reg {
+  union {
+    struct {
+      BYTE h;
+      BYTE l;
+    };
+    WORD w;
+  };
+};
+#else
+#error "Unsupported byte order"
+#endif
+
 // 8080 CPU state
 struct cpu_state {
-  BYTE A, B, C, D, E, H, L, F, IFF;
-  WORD PC8, SP8; // funny names because SP already is a macro here
+  struct cpu_reg af;	/* primary registers */
+  struct cpu_reg bc;
+  struct cpu_reg de;
+  struct cpu_reg hl;
+  struct cpu_reg sp;	/* stack pointer */
+  struct cpu_reg pc;	/* program counter */
+  BYTE iff;         	/* interupt flags */
 } cpu_state;
 
 // other global variables
@@ -60,45 +89,43 @@ SdFat32 SD;
 #define Z Z_FLAG
 #define P P_FLAG
 static const BYTE szp_flags[256] = {
-/*00*/ Z | P,     _,     _,     P,     _,     P,     P,     _,
-/*08*/     _,     P,     P,     _,     P,     _,     _,     P,
-/*10*/     _,     P,     P,     _,     P,     _,     _,     P,
-/*18*/     P,     _,     _,     P,     _,     P,     P,     _,
-/*20*/     _,     P,     P,     _,     P,     _,     _,     P,
-/*28*/     P,     _,     _,     P,     _,     P,     P,     _,
-/*30*/     P,     _,     _,     P,     _,     P,     P,     _,
-/*38*/     _,     P,     P,     _,     P,     _,     _,     P,
-/*40*/     _,     P,     P,     _,     P,     _,     _,     P,
-/*48*/     P,     _,     _,     P,     _,     P,     P,     _,
-/*50*/     P,     _,     _,     P,     _,     P,     P,     _,
-/*58*/     _,     P,     P,     _,     P,     _,     _,     P,
-/*60*/     P,     _,     _,     P,     _,     P,     P,     _,
-/*68*/     _,     P,     P,     _,     P,     _,     _,     P,
-/*70*/     _,     P,     P,     _,     P,     _,     _,     P,
-/*78*/     P,     _,     _,     P,     _,     P,     P,     _,
-/*80*/     S, S | P, S | P,     S, S | P,     S,     S, S | P,
-/*88*/ S | P,     S,     S, S | P,     S, S | P, S | P,     S,
-/*90*/ S | P,     S,     S, S | P,     S, S | P, S | P,     S,
-/*98*/     S, S | P, S | P,     S, S | P,     S,     S, S | P,
-/*a0*/ S | P,     S,     S, S | P,     S, S | P, S | P,     S,
-/*a8*/     S, S | P, S | P,     S, S | P,     S,     S, S | P,
-/*b0*/     S, S | P, S | P,     S, S | P,     S,     S, S | P,
-/*b8*/ S | P,     S,     S, S | P,     S, S | P, S | P,     S,
-/*c0*/ S | P,     S,     S, S | P,     S, S | P, S | P,     S,
-/*c8*/     S, S | P, S | P,     S, S | P,     S,     S, S | P,
-/*d0*/     S, S | P, S | P,     S, S | P,     S,     S, S | P,
-/*d8*/ S | P,     S,     S, S | P,     S, S | P, S | P,     S,
-/*e0*/     S, S | P, S | P,     S, S | P,     S,     S, S | P,
-/*e8*/ S | P,     S,     S, S | P,     S, S | P, S | P,     S,
-/*f0*/ S | P,     S,     S, S | P,     S, S | P, S | P,     S,
-/*f8*/     S, S | P, S | P,     S, S | P,     S,     S, S | P
+  /*00*/ Z|P,   _,   _,   P,   _,   P,   P,   _,
+  /*08*/   _,   P,   P,   _,   P,   _,   _,   P,
+  /*10*/   _,   P,   P,   _,   P,   _,   _,   P,
+  /*18*/   P,   _,   _,   P,   _,   P,   P,   _,
+  /*20*/   _,   P,   P,   _,   P,   _,   _,   P,
+  /*28*/   P,   _,   _,   P,   _,   P,   P,   _,
+  /*30*/   P,   _,   _,   P,   _,   P,   P,   _,
+  /*38*/   _,   P,   P,   _,   P,   _,   _,   P,
+  /*40*/   _,   P,   P,   _,   P,   _,   _,   P,
+  /*48*/   P,   _,   _,   P,   _,   P,   P,   _,
+  /*50*/   P,   _,   _,   P,   _,   P,   P,   _,
+  /*58*/   _,   P,   P,   _,   P,   _,   _,   P,
+  /*60*/   P,   _,   _,   P,   _,   P,   P,   _,
+  /*68*/   _,   P,   P,   _,   P,   _,   _,   P,
+  /*70*/   _,   P,   P,   _,   P,   _,   _,   P,
+  /*78*/   P,   _,   _,   P,   _,   P,   P,   _,
+  /*80*/   S, S|P, S|P,   S, S|P,   S,   S, S|P,
+  /*88*/ S|P,   S,   S, S|P,   S, S|P, S|P,   S,
+  /*90*/ S|P,   S,   S, S|P,   S, S|P, S|P,   S,
+  /*98*/   S, S|P, S|P,   S, S|P,   S,   S, S|P,
+  /*a0*/ S|P,   S,   S, S|P,   S, S|P, S|P,   S,
+  /*a8*/   S, S|P, S|P,   S, S|P,   S,   S, S|P,
+  /*b0*/   S, S|P, S|P,   S, S|P,   S,   S, S|P,
+  /*b8*/ S|P,   S,   S, S|P,   S, S|P, S|P,   S,
+  /*c0*/ S|P,   S,   S, S|P,   S, S|P, S|P,   S,
+  /*c8*/   S, S|P, S|P,   S, S|P,   S,   S, S|P,
+  /*d0*/   S, S|P, S|P,   S, S|P,   S,   S, S|P,
+  /*d8*/ S|P,   S,   S, S|P,   S, S|P, S|P,   S,
+  /*e0*/   S, S|P, S|P,   S, S|P,   S,   S, S|P,
+  /*e8*/ S|P,   S,   S, S|P,   S, S|P, S|P,   S,
+  /*f0*/ S|P,   S,   S, S|P,   S, S|P, S|P,   S,
+  /*f8*/   S, S|P, S|P,   S, S|P,   S,   S, S|P
 };
 #undef _
 #undef S
 #undef Z
 #undef P
-
-#define SZP_FLAGS (S_FLAG | Z_FLAG | P_FLAG)
 
 // This function initializes the CPU into the documented
 // state. Prevents assumptions about register contents
@@ -106,16 +133,12 @@ static const BYTE szp_flags[256] = {
 // beginning, which is not the case with the silicon.
 static void init_cpu(struct cpu_state *cpu_state)
 {
-  cpu_state->PC8 = 0;
-  cpu_state->SP8 = random(65535);
-  cpu_state->A = random(255);
-  cpu_state->B = random(255);
-  cpu_state->C = random(255);
-  cpu_state->D = random(255);
-  cpu_state->E = random(255);
-  cpu_state->H = random(255);
-  cpu_state->L = random(255);
-  cpu_state->F = random(255);
+  cpu_state->pc.w = 0;
+  cpu_state->sp.w = random(65535);
+  cpu_state->af.w = random(65535);
+  cpu_state->bc.w = random(65535);
+  cpu_state->de.w = random(65535);
+  cpu_state->hl.w = random(65535);
 }
 
 // This function builds the 8080 central processing unit.
@@ -133,1350 +156,1395 @@ static void init_cpu(struct cpu_state *cpu_state)
 
 void cpu_8080(struct cpu_state *cpu_state)
 {
-  BYTE A, B, C, D, E, H, L, F, IFF;
-  WORD PC8, SP8;
+  struct cpu_state cpu_regs;
   BYTE t, res, cout, P;
-  WORD W;
 
-  A = cpu_state->A;
-  B = cpu_state->B;
-  C = cpu_state->C;
-  D = cpu_state->D;
-  E = cpu_state->E;
-  H = cpu_state->H;
-  L = cpu_state->L;
-  F = cpu_state->F;
-  IFF = cpu_state->IFF;
-  PC8 = cpu_state->PC8;
-  SP8 = cpu_state->SP8;
+  struct cpu_reg w;		/* working register */
+
+#pragma push_macro("F")
+#undef F
+#pragma push_macro("SP")
+#undef SP
+#pragma push_macro("PC")
+#undef PC
+
+#define AF	cpu_regs.af.w
+#define A	cpu_regs.af.h
+#define F	cpu_regs.af.l
+#define BC	cpu_regs.bc.w
+#define B	cpu_regs.bc.h
+#define C	cpu_regs.bc.l
+#define DE	cpu_regs.de.w
+#define D	cpu_regs.de.h
+#define E	cpu_regs.de.l
+#define HL	cpu_regs.hl.w
+#define H	cpu_regs.hl.h
+#define L	cpu_regs.hl.l
+#define SP	cpu_regs.sp.w
+#define SPH	cpu_regs.sp.h
+#define SPL	cpu_regs.sp.l
+#define PC	cpu_regs.pc.w
+#define PCH	cpu_regs.pc.h
+#define PCL	cpu_regs.pc.l
+#define IFF	cpu_regs.iff
+
+#define W	w.w
+#define WH	w.h
+#define WL	w.l
+
+  cpu_regs = *cpu_state;
 
   do {
-    t = 4; // minimum clock cycles for M1
+    t = 4;			/* minimum clock cycles for M1 */
 
-    switch (memrdr(PC8++)) {	/* execute next opcode */
+    switch (memrdr(PC++)) {	/* execute next opcode */
 
-    case 0x00:			/* NOP */
-    case 0x08:			/* NOP* */
-    case 0x10:			/* NOP* */
-    case 0x18:			/* NOP* */
-    case 0x20:			/* NOP* */
-    case 0x28:			/* NOP* */
-    case 0x30:			/* NOP* */
-    case 0x38:			/* NOP* */
-      break;
+      case 0x00:		/* NOP */
+      case 0x08:		/* NOP* */
+      case 0x10:		/* NOP* */
+      case 0x18:		/* NOP* */
+      case 0x20:		/* NOP* */
+      case 0x28:		/* NOP* */
+      case 0x30:		/* NOP* */
+      case 0x38:		/* NOP* */
+        break;
 
-    case 0x40:			/* MOV B,B */
-    case 0x49:			/* MOV C,C */
-    case 0x52:			/* MOV D,D */
-    case 0x5b:			/* MOV E,E */
-    case 0x64:			/* MOV H,H */
-    case 0x6d:			/* MOV L,L */
-    case 0x7f:			/* MOV A,A */
-      t++;
-      break;
+      case 0x40:		/* MOV B,B */
+      case 0x49:		/* MOV C,C */
+      case 0x52:		/* MOV D,D */
+      case 0x5b:		/* MOV E,E */
+      case 0x64:		/* MOV H,H */
+      case 0x6d:		/* MOV L,L */
+      case 0x7f:		/* MOV A,A */
+        t++;
+        break;
 
-    case 0x01:			/* LXI B,nn */
-      C = memrdr(PC8++);
-      B = memrdr(PC8++);
-      t += 6;
-      break;
+      case 0x01:		/* LXI B,nn */
+        C = memrdr(PC++);
+        B = memrdr(PC++);
+        t += 6;
+        break;
 
-    case 0x02:			/* STAX B */
-      memwrt((B << 8) | C, A);
-      t += 3;
-      break;
+      case 0x02:		/* STAX B */
+        memwrt(BC, A);
+        t += 3;
+        break;
 
-    case 0x03:			/* INX B */
-      W = ((B << 8) | C) + 1;
-      B = W >> 8;
-      C = W & 0xff;
-      t++;
-      break;
+      case 0x03:		/* INX B */
+        BC++;
+        t++;
+        break;
 
-    case 0x04:			/* INR B */
-      P = B;
-      res = ++B;
-    finish_inr:
-      cout = (P & 1) | ((P | 1) & ~res);
-      F = ((F & C_FLAG) |
-           (((cout >> 3) & 1) << H_SHIFT) |
-           szp_flags[res]);
-      /* C_FLAG unchanged */
-      t++;
-      break;
+      case 0x04:		/* INR B */
+        P = B;
+        res = ++B;
+finish_inr:
+        cout = (P & 1) | ((P | 1) & ~res);
+        F = ((F & C_FLAG) |
+             (((cout >> 3) & 1) << H_SHIFT) |
+             szp_flags[res]);
+        /* C_FLAG unchanged */
+        t++;
+        break;
 
-    case 0x05:			/* DCR B */
-      P = B;
-      res = --B;
-    finish_dcr:
-      cout = (~P & 1) | ((~P | 1) & res);
-      F = ((F & C_FLAG) |
-           (((cout >> 3) & 1) << H_SHIFT) |
-           szp_flags[res]);
-      F ^= H_FLAG;
-      /* C_FLAG unchanged */
-      t++;
-      break;
+      case 0x05:		/* DCR B */
+        P = B;
+        res = --B;
+finish_dcr:
+        cout = (~P & 1) | ((~P | 1) & res);
+        F = ((F & C_FLAG) |
+             (((cout >> 3) & 1) << H_SHIFT) |
+             szp_flags[res]);
+        F ^= H_FLAG;
+        /* C_FLAG unchanged */
+        t++;
+        break;
 
-    case 0x06:			/* MVI B,n */
-      B = memrdr(PC8++);
-      t += 3;
-      break;
+      case 0x06:		/* MVI B,n */
+        B = memrdr(PC++);
+        t += 3;
+        break;
 
-    case 0x07:			/* RLC */
-      res = ((A & 0x80) >> 7) & 1;
-      F = (F & ~C_FLAG) | (res << C_SHIFT);
-      /* S_FLAG, Z_FLAG, H_FLAG, and P_FLAG unchanged */
-      A = (A << 1) | res;
-      break;
+      case 0x07:		/* RLC */
+        res = ((A & 0x80) >> 7) & 1;
+        F = (F & ~C_FLAG) | (res << C_SHIFT);
+        /* S_FLAG, Z_FLAG, H_FLAG, and P_FLAG unchanged */
+        A = (A << 1) | res;
+        break;
 
-    case 0x09:			/* DAD B */
-      W = ((H << 8) | L) + ((B << 8) | C);
-      cout = (H & B) | ((H | B) & ~(W >> 8));
-    finish_dad:
-      F = (F & ~C_FLAG) | (((cout >> 7) & 1) << C_SHIFT);
-      /* S_FLAG, Z_FLAG, H_FLAG, and P_FLAG unchanged */
-      H = W >> 8;
-      L = W & 0xff;
-      t += 6;
-      break;
+      case 0x09:		/* DAD B */
+        W = HL + BC;
+        cout = (H & B) | ((H | B) & ~WH);
+finish_dad:
+        F = (F & ~C_FLAG) | (((cout >> 7) & 1) << C_SHIFT);
+        /* S_FLAG, Z_FLAG, H_FLAG, and P_FLAG unchanged */
+        H = WH;
+        L = WL;
+        t += 6;
+        break;
 
-    case 0x0a:			/* LDAX B */
-      A = memrdr((B << 8) | C);
-      t += 3;
-      break;
+      case 0x0a:		/* LDAX B */
+        A = memrdr(BC);
+        t += 3;
+        break;
 
-    case 0x0b:			/* DCX B */
-      W = ((B << 8) | C) - 1;
-      B = W >> 8;
-      C = W & 0xff;
-      t++;
-      break;
+      case 0x0b:		/* DCX B */
+        BC--;
+        t++;
+        break;
 
-    case 0x0c:			/* INR C */
-      P = C;
-      res = ++C;
-      goto finish_inr;
+      case 0x0c:		/* INR C */
+        P = C;
+        res = ++C;
+        goto finish_inr;
 
-    case 0x0d:			/* DCR C */
-      P = C;
-      res = --C;
-      goto finish_dcr;
+      case 0x0d:		/* DCR C */
+        P = C;
+        res = --C;
+        goto finish_dcr;
 
-    case 0x0e:			/* MVI C,n */
-      C = memrdr(PC8++);
-      t += 3;
-      break;
+      case 0x0e:		/* MVI C,n */
+        C = memrdr(PC++);
+        t += 3;
+        break;
 
-    case 0x0f:			/* RRC */
-      res = A & 1;
-      F = (F & ~C_FLAG) | (res << C_SHIFT);
-      /* S_FLAG, Z_FLAG, H_FLAG, and P_FLAG unchanged */
-      A = (A >> 1) | (res << 7);
-      break;
+      case 0x0f:		/* RRC */
+        res = A & 1;
+        F = (F & ~C_FLAG) | (res << C_SHIFT);
+        /* S_FLAG, Z_FLAG, H_FLAG, and P_FLAG unchanged */
+        A = (A >> 1) | (res << 7);
+        break;
 
-    case 0x11:			/* LXI D,nn */
-      E = memrdr(PC8++);
-      D = memrdr(PC8++);
-      t += 6;
-      break;
+      case 0x11:		/* LXI D,nn */
+        E = memrdr(PC++);
+        D = memrdr(PC++);
+        t += 6;
+        break;
 
-    case 0x12:			/* STAX D */
-      memwrt((D << 8) | E, A);
-      t += 3;
-      break;
+      case 0x12:		/* STAX D */
+        memwrt(DE, A);
+        t += 3;
+        break;
 
-    case 0x13:			/* INX D */
-      W = ((D << 8) | E) + 1;
-      D = W >> 8;
-      E = W & 0xff;
-      t++;
-      break;
+      case 0x13:		/* INX D */
+        DE++;
+        t++;
+        break;
 
-    case 0x14:			/* INR D */
-      P = D;
-      res = ++D;
-      goto finish_inr;
+      case 0x14:		/* INR D */
+        P = D;
+        res = ++D;
+        goto finish_inr;
 
-    case 0x15:			/* DCR D */
-      P = D;
-      res = --D;
-      goto finish_dcr;
+      case 0x15:		/* DCR D */
+        P = D;
+        res = --D;
+        goto finish_dcr;
 
-    case 0x16:			/* MVI D,n */
-      D = memrdr(PC8++);
-      t += 3;
-      break;
+      case 0x16:		/* MVI D,n */
+        D = memrdr(PC++);
+        t += 3;
+        break;
 
-    case 0x17:			/* RAL */
-      res = (F >> C_SHIFT) & 1;
-      F = (F & ~C_FLAG) | ((((A & 0x80) >> 7) & 1) << C_SHIFT);
-      /* S_FLAG, Z_FLAG, H_FLAG, and P_FLAG unchanged */
-      A = (A << 1) | res;
-      break;
+      case 0x17:		/* RAL */
+        res = (F >> C_SHIFT) & 1;
+        F = (F & ~C_FLAG) | ((((A & 0x80) >> 7) & 1) << C_SHIFT);
+        /* S_FLAG, Z_FLAG, H_FLAG, and P_FLAG unchanged */
+        A = (A << 1) | res;
+        break;
 
-    case 0x19:			/* DAD D */
-      W = ((H << 8) | L) + ((D << 8) | E);
-      cout = (H & D) | ((H | D) & ~(W >> 8));
-      goto finish_dad;
+      case 0x19:		/* DAD D */
+        W = HL + DE;
+        cout = (H & D) | ((H | D) & ~WH);
+        goto finish_dad;
 
-    case 0x1a:			/* LDAX D */
-      A = memrdr((D << 8) | E);
-      t += 3;
-      break;
+      case 0x1a:		/* LDAX D */
+        A = memrdr(DE);
+        t += 3;
+        break;
 
-    case 0x1b:			/* DCX D */
-      W = ((D << 8) | E) - 1;
-      D = W >> 8;
-      E = W & 0xff;
-      t++;
-      break;
+      case 0x1b:		/* DCX D */
+        DE--;
+        t++;
+        break;
 
-    case 0x1c:			/* INR E */
-      P = E;
-      res = ++E;
-      goto finish_inr;
+      case 0x1c:		/* INR E */
+        P = E;
+        res = ++E;
+        goto finish_inr;
 
-    case 0x1d:			/* DCR E */
-      P = E;
-      res = --E;
-      goto finish_dcr;
+      case 0x1d:		/* DCR E */
+        P = E;
+        res = --E;
+        goto finish_dcr;
 
-    case 0x1e:			/* MVI E,n */
-      E = memrdr(PC8++);
-      t += 3;
-      break;
+      case 0x1e:		/* MVI E,n */
+        E = memrdr(PC++);
+        t += 3;
+        break;
 
-    case 0x1f:			/* RAR */
-      res = (F >> C_SHIFT) & 1;
-      F = (F & ~C_FLAG) | ((A & 1) << C_SHIFT);
-      /* S_FLAG, Z_FLAG, H_FLAG, and P_FLAG unchanged */
-      A = (A >> 1) | (res << 7);
-      break;
+      case 0x1f:		/* RAR */
+        res = (F >> C_SHIFT) & 1;
+        F = (F & ~C_FLAG) | ((A & 1) << C_SHIFT);
+        /* S_FLAG, Z_FLAG, H_FLAG, and P_FLAG unchanged */
+        A = (A >> 1) | (res << 7);
+        break;
 
-    case 0x21:			/* LXI H,nn */
-      L = memrdr(PC8++);
-      H = memrdr(PC8++);
-      t += 6;
-      break;
+      case 0x21:		/* LXI H,nn */
+        L = memrdr(PC++);
+        H = memrdr(PC++);
+        t += 6;
+        break;
 
-    case 0x22:			/* SHLD nn */
-      W = memrdr(PC8++);
-      W |= memrdr(PC8++) << 8;
-      memwrt(W, L);
-      memwrt(W + 1, H);
-      t += 12;
-      break;
+      case 0x22:		/* SHLD nn */
+        WL = memrdr(PC++);
+        WH = memrdr(PC++);
+        memwrt(W, L);
+        memwrt(W + 1, H);
+        t += 12;
+        break;
 
-    case 0x23:			/* INX H */
-      W = ((H << 8) | L) + 1;
-      H = W >> 8;
-      L = W & 0xff;
-      t++;
-      break;
+      case 0x23:		/* INX H */
+        HL++;
+        t++;
+        break;
 
-    case 0x24:			/* INR H */
-      P = H;
-      res = ++H;
-      goto finish_inr;
+      case 0x24:		/* INR H */
+        P = H;
+        res = ++H;
+        goto finish_inr;
 
-    case 0x25:			/* DCR H */
-      P = H;
-      res = --H;
-      goto finish_dcr;
+      case 0x25:		/* DCR H */
+        P = H;
+        res = --H;
+        goto finish_dcr;
 
-    case 0x26:			/* MVI H,n */
-      H = memrdr(PC8++);
-      t += 3;
-      break;
+      case 0x26:		/* MVI H,n */
+        H = memrdr(PC++);
+        t += 3;
+        break;
 
-    case 0x27:			/* DAA */
-      P = 0;
-      if (((A & 0xf) > 9) || (F & H_FLAG))
-        P |= 0x06;
-      if ((A > 0x99) || (F & C_FLAG)) {
+      case 0x27:		/* DAA */
+        P = 0;
+        if (((A & 0xf) > 9) || (F & H_FLAG))
+          P |= 0x06;
+        if ((A > 0x99) || (F & C_FLAG)) {
+          F |= C_FLAG;
+          P |= 0x60;
+        }
+        res = A + P;
+        cout = (A & P) | ((A | P) & ~res);
+        F = ((F & C_FLAG) |
+             (((cout >> 3) & 1) << H_SHIFT) |
+             szp_flags[res]);
+        A = res;
+        break;
+
+      case 0x29:		/* DAD H */
+        W = HL << 1;
+        cout = H | (H & ~WH);
+        goto finish_dad;
+
+      case 0x2a:		/* LHLD nn */
+        WL = memrdr(PC++);
+        WH = memrdr(PC++);
+        L = memrdr(W);
+        H = memrdr(W + 1);
+        t += 12;
+        break;
+
+      case 0x2b:		/* DCX H */
+        HL--;
+        t++;
+        break;
+
+      case 0x2c:		/* INR L */
+        P = L;
+        res = ++L;
+        goto finish_inr;
+
+      case 0x2d:		/* DCR L */
+        P = L;
+        res = --L;
+        goto finish_dcr;
+
+      case 0x2e:		/* MVI L,n */
+        L = memrdr(PC++);
+        t += 3;
+        break;
+
+      case 0x2f:		/* CMA */
+        A = ~A;
+        break;
+
+      case 0x31:		/* LXI SP,nn */
+        SPL = memrdr(PC++);
+        SPH = memrdr(PC++);
+        t += 6;
+        break;
+
+      case 0x32:		/* STA nn */
+        WL = memrdr(PC++);
+        WH = memrdr(PC++);
+        memwrt(W, A);
+        t += 9;
+        break;
+
+      case 0x33:		/* INX SP */
+        SP++;
+        t++;
+        break;
+
+      case 0x34:		/* INR M */
+        P = memrdr(HL);
+        res = P + 1;
+        memwrt(HL, res);
+        t += 5;
+        goto finish_inr;
+
+      case 0x35:		/* DCR M */
+        P = memrdr(HL);
+        res = P - 1;
+        memwrt(HL, res);
+        t += 5;
+        goto finish_dcr;
+
+      case 0x36:		/* MVI M,n */
+        memwrt(HL, memrdr(PC++));
+        t += 6;
+        break;
+
+      case 0x37:		/* STC */
         F |= C_FLAG;
-        P |= 0x60;
-      }
-      res = A + P;
-      cout = (A & P) | ((A | P) & ~res);
-      F = ((F & C_FLAG) |
-           (((cout >> 3) & 1) << H_SHIFT) |
-           szp_flags[res]);
-      A = res;
-      break;
-
-    case 0x29:			/* DAD H */
-      W = ((H << 8) | L) << 1;
-      cout = H | (H & ~(W >> 8));
-      goto finish_dad;
-
-    case 0x2a:			/* LHLD nn */
-      W = memrdr(PC8++);
-      W |= memrdr(PC8++) << 8;
-      L = memrdr(W);
-      H = memrdr(W + 1);
-      t += 12;
-      break;
-
-    case 0x2b:			/* DCX H */
-      W = ((H << 8) | L) - 1;
-      H = W >> 8;
-      L = W & 0xff;
-      t++;
-      break;
-
-    case 0x2c:			/* INR L */
-      P = L;
-      res = ++L;
-      goto finish_inr;
-
-    case 0x2d:			/* DCR L */
-      P = L;
-      res = --L;
-      goto finish_dcr;
-
-    case 0x2e:			/* MVI L,n */
-      L = memrdr(PC8++);
-      t += 3;
-      break;
-
-    case 0x2f:			/* CMA */
-      A = ~A;
-      break;
-
-    case 0x31:			/* LXI SP,nn */
-      SP8 = memrdr(PC8++);
-      SP8 |= memrdr(PC8++) << 8;
-      t += 6;
-      break;
-
-    case 0x32:			/* STA nn */
-      W = memrdr(PC8++);
-      W |= memrdr(PC8++) << 8;
-      memwrt(W, A);
-      t += 9;
-      break;
-
-    case 0x33:			/* INX SP */
-      SP8++;
-      t++;
-      break;
-
-    case 0x34:			/* INR M */
-      W = (H << 8) | L;
-      P = memrdr(W);
-      res = P + 1;
-      memwrt(W, res);
-      t += 5;
-      goto finish_inr;
-
-    case 0x35:			/* DCR M */
-      W = (H << 8) | L;
-      P = memrdr(W);
-      res = P - 1;
-      memwrt(W, res);
-      t += 5;
-      goto finish_dcr;
-
-    case 0x36:			/* MVI M,n */
-      memwrt((H << 8) | L, memrdr(PC8++));
-      t += 6;
-      break;
-
-    case 0x37:			/* STC */
-      F |= C_FLAG;
-      /* S_FLAG, Z_FLAG, H_FLAG, and P_FLAG unchanged */
-      break;
-
-    case 0x39:			/* DAD SP */
-      W = ((H << 8) | L) + SP8;
-      cout = (H & (SP8 >> 8)) | ((H | (SP8 >> 8)) & ~(W >> 8));
-      goto finish_dad;
-
-    case 0x3a:			/* LDA nn */
-      W = memrdr(PC8++);
-      W |= memrdr(PC8++) << 8;
-      A = memrdr(W);
-      t += 9;
-      break;
-
-    case 0x3b:			/* DCX SP */
-      SP8--;
-      t++;
-      break;
-
-    case 0x3c:			/* INR A */
-      P = A;
-      res = ++A;
-      goto finish_inr;
-
-    case 0x3d:			/* DCR A */
-      P = A;
-      res = --A;
-      goto finish_dcr;
-
-    case 0x3e:			/* MVI A,n */
-      A = memrdr(PC8++);
-      t += 3;
-      break;
-
-    case 0x3f:			/* CMC */
-      F ^= C_FLAG;
-      /* S_FLAG, Z_FLAG, H_FLAG, and P_FLAG unchanged */
-      break;
-
-    case 0x41:			/* MOV B,C */
-      B = C;
-      t++;
-      break;
-
-    case 0x42:			/* MOV B,D */
-      B = D;
-      t++;
-      break;
-
-    case 0x43:			/* MOV B,E */
-      B = E;
-      t++;
-      break;
-
-    case 0x44:			/* MOV B,H */
-      B = H;
-      t++;
-      break;
-
-    case 0x45:			/* MOV B,L */
-      B = L;
-      t++;
-      break;
-
-    case 0x46:			/* MOV B,M */
-      B = memrdr((H << 8) | L);
-      t += 3;
-      break;
-
-    case 0x47:			/* MOV B,A */
-      B = A;
-      t++;
-      break;
-
-    case 0x48:			/* MOV C,B */
-      C = B;
-      t++;
-      break;
-
-    case 0x4a:			/* MOV C,D */
-      C = D;
-      t++;
-      break;
-
-    case 0x4b:			/* MOV C,E */
-      C = E;
-      t++;
-      break;
-
-    case 0x4c:			/* MOV C,H */
-      C = H;
-      t++;
-      break;
-
-    case 0x4d:			/* MOV C,L */
-      C = L;
-      t++;
-      break;
-
-    case 0x4e:			/* MOV C,M */
-      C = memrdr((H << 8) | L);
-      t += 3;
-      break;
-
-    case 0x4f:			/* MOV C,A */
-      C = A;
-      t++;
-      break;
-
-    case 0x50:			/* MOV D,B */
-      D = B;
-      t++;
-      break;
-
-    case 0x51:			/* MOV D,C */
-      D = C;
-      t++;
-      break;
-
-    case 0x53:			/* MOV D,E */
-      D = E;
-      t++;
-      break;
-
-    case 0x54:			/* MOV D,H */
-      D = H;
-      t++;
-      break;
-
-    case 0x55:			/* MOV D,L */
-      D = L;
-      t++;
-      break;
-
-    case 0x56:			/* MOV D,M */
-      D = memrdr((H << 8) | L);
-      t += 3;
-      break;
-
-    case 0x57:			/* MOV D,A */
-      D = A;
-      t++;
-      break;
-
-    case 0x58:			/* MOV E,B */
-      E = B;
-      t++;
-      break;
-
-    case 0x59:			/* MOV E,C */
-      E = C;
-      t++;
-      break;
-
-    case 0x5a:			/* MOV E,D */
-      E = D;
-      t++;
-      break;
-
-    case 0x5c:			/* MOV E,H */
-      E = H;
-      t++;
-      break;
-
-    case 0x5d:			/* MOV E,L */
-      E = L;
-      t++;
-      break;
-
-    case 0x5e:			/* MOV E,M */
-      E = memrdr((H << 8) | L);
-      t += 3;
-      break;
-
-    case 0x5f:			/* MOV E,A */
-      E = A;
-      t++;
-      break;
-
-    case 0x60:			/* MOV H,B */
-      H = B;
-      t++;
-      break;
-
-    case 0x61:			/* MOV H,C */
-      H = C;
-      t++;
-      break;
-
-    case 0x62:			/* MOV H,D */
-      H = D;
-      t++;
-      break;
-
-    case 0x63:			/* MOV H,E */
-      H = E;
-      t++;
-      break;
-
-    case 0x65:			/* MOV H,L */
-      H = L;
-      t++;
-      break;
-
-    case 0x66:			/* MOV H,M */
-      H = memrdr((H << 8) | L);
-      t += 3;
-      break;
-
-    case 0x67:			/* MOV H,A */
-      H = A;
-      t++;
-      break;
-
-    case 0x68:			/* MOV L,B */
-      L = B;
-      t++;
-      break;
-
-    case 0x69:			/* MOV L,C */
-      L = C;
-      t++;
-      break;
-
-    case 0x6a:			/* MOV L,D */
-      L = D;
-      t++;
-      break;
-
-    case 0x6b:			/* MOV L,E */
-      L = E;
-      t++;
-      break;
-
-    case 0x6c:			/* MOV L,H */
-      L = H;
-      t++;
-      break;
-
-    case 0x6e:			/* MOV L,M */
-      L = memrdr((H << 8) | L);
-      t += 3;
-      break;
-
-    case 0x6f:			/* MOV L,A */
-      L = A;
-      t++;
-      break;
-
-    case 0x70:			/* MOV M,B */
-      memwrt((H << 8) | L, B);
-      t += 3;
-      break;
-
-    case 0x71:			/* MOV M,C */
-      memwrt((H << 8) | L, C);
-      t += 3;
-      break;
-
-    case 0x72:			/* MOV M,D */
-      memwrt((H << 8) | L, D);
-      t += 3;
-      break;
-
-    case 0x73:			/* MOV M,E */
-      memwrt((H << 8) | L, E);
-      t += 3;
-      break;
-
-    case 0x74:			/* MOV M,H */
-      memwrt((H << 8) | L, H);
-      t += 3;
-      break;
-
-    case 0x75:			/* MOV M,L */
-      memwrt((H << 8) | L, L);
-      t += 3;
-      break;
-
-    case 0x76:			/* HLT */
-      // cry and die, no interrupts yet
-      State = Halted;
-      t += 3;
-      break;
-
-    case 0x77:			/* MOV M,A */
-      memwrt((H << 8) | L, A);
-      t += 3;
-      break;
-
-    case 0x78:			/* MOV A,B */
-      A = B;
-      t++;
-      break;
-
-    case 0x79:			/* MOV A,C */
-      A = C;
-      t++;
-      break;
-
-    case 0x7a:			/* MOV A,D */
-      A = D;
-      t++;
-      break;
-
-    case 0x7b:			/* MOV A,E */
-      A = E;
-      t++;
-      break;
-
-    case 0x7c:			/* MOV A,H */
-      A = H;
-      t++;
-      break;
-
-    case 0x7d:			/* MOV A,L */
-      A = L;
-      t++;
-      break;
-
-    case 0x7e:			/* MOV A,M */
-      A = memrdr((H << 8) | L);
-      t += 3;
-      break;
-
-    case 0x80:			/* ADD B */
-      P = B;
-    finish_add:
-      res = A + P;
-      cout = (A & P) | ((A | P) & ~res);
-      F = ((((cout >> 7) & 1) << C_SHIFT) |
-           (((cout >> 3) & 1) << H_SHIFT) |
-           szp_flags[res]);
-      A = res;
-      break;
-
-    case 0x81:			/* ADD C */
-      P = C;
-      goto finish_add;
-
-    case 0x82:			/* ADD D */
-      P = D;
-      goto finish_add;
-
-    case 0x83:			/* ADD E */
-      P = E;
-      goto finish_add;
-
-    case 0x84:			/* ADD H */
-      P = H;
-      goto finish_add;
-
-    case 0x85:			/* ADD L */
-      P = L;
-      goto finish_add;
-
-    case 0x86:			/* ADD M */
-      P = memrdr((H << 8) | L);
-      t += 3;
-      goto finish_add;
-
-    case 0x87:			/* ADD A */
-      P = A;
-      goto finish_add;
-
-    case 0x88:			/* ADC B */
-      P = B;
-    finish_adc:
-      res = A + P + ((F >> C_SHIFT) & 1);
-      cout = (A & P) | ((A | P) & ~res);
-      F = ((((cout >> 7) & 1) << C_SHIFT) |
-           (((cout >> 3) & 1) << H_SHIFT) |
-           szp_flags[res]);
-      A = res;
-      break;
-
-    case 0x89:			/* ADC C */
-      P = C;
-      goto finish_adc;
-
-    case 0x8a:			/* ADC D */
-      P = D;
-      goto finish_adc;
-
-    case 0x8b:			/* ADC E */
-      P = E;
-      goto finish_adc;
-
-    case 0x8c:			/* ADC H */
-      P = H;
-      goto finish_adc;
-
-    case 0x8d:			/* ADC L */
-      P = L;
-      goto finish_adc;
-
-    case 0x8e:			/* ADC M */
-      P = memrdr((H << 8) | L);
-      t += 3;
-      goto finish_adc;
-
-    case 0x8f:			/* ADC A */
-      P = A;
-      goto finish_adc;
-
-    case 0x90:			/* SUB B */
-      P = B;
-    finish_sub:
-      res = A - P;
-      cout = (~A & P) | ((~A | P) & res);
-      F = ((((cout >> 7) & 1) << C_SHIFT) |
-           (((cout >> 3) & 1) << H_SHIFT) |
-           szp_flags[res]);
-      F ^= H_FLAG;
-      A = res;
-      break;
-
-    case 0x91:			/* SUB C */
-      P = C;
-      goto finish_sub;
-
-    case 0x92:			/* SUB D */
-      P = D;
-      goto finish_sub;
-
-    case 0x93:			/* SUB E */
-      P = E;
-      goto finish_sub;
-
-    case 0x94:			/* SUB H */
-      P = H;
-      goto finish_sub;
-
-    case 0x95:			/* SUB L */
-      P = L;
-      goto finish_sub;
-
-    case 0x96:			/* SUB M */
-      P = memrdr((H << 8) | L);
-      t += 3;
-      goto finish_sub;
-
-    case 0x97:			/* SUB A */
-      F = Z_FLAG | H_FLAG | P_FLAG;
-      /* S_FLAG and C_FLAG cleared */
-      A = 0;
-      break;
-
-    case 0x98:			/* SBB B */
-      P = B;
-    finish_sbb:
-      res = A - P - ((F >> C_SHIFT) & 1);
-      cout = (~A & P) | ((~A | P) & res);
-      F = ((((cout >> 7) & 1) << C_SHIFT) |
-           (((cout >> 3) & 1) << H_SHIFT) |
-           szp_flags[res]);
-      F ^= H_FLAG;
-      A = res;
-      break;
-
-    case 0x99:			/* SBB C */
-      P = C;
-      goto finish_sbb;
-
-    case 0x9a:			/* SBB D */
-      P = D;
-      goto finish_sbb;
-
-    case 0x9b:			/* SBB E */
-      P = E;
-      goto finish_sbb;
-
-    case 0x9c:			/* SBB H */
-      P = H;
-      goto finish_sbb;
-
-    case 0x9d:			/* SBB L */
-      P = L;
-      goto finish_sbb;
-
-    case 0x9e:			/* SBB M */
-      P = memrdr((H << 8) | L);
-      t += 3;
-      goto finish_sbb;
-
-    case 0x9f:			/* SBB A */
-      P = A;
-      goto finish_sbb;
-
-    case 0xa0:			/* ANA B */
-      P = B;
-    finish_ana:
-      res = A & P;
+        /* S_FLAG, Z_FLAG, H_FLAG, and P_FLAG unchanged */
+        break;
+
+      case 0x39:		/* DAD SP */
+        W = HL + SP;
+        cout = (H & SPH) | ((H | SPH) & ~WH);
+        goto finish_dad;
+
+      case 0x3a:		/* LDA nn */
+        WL = memrdr(PC++);
+        WH = memrdr(PC++);
+        A = memrdr(W);
+        t += 9;
+        break;
+
+      case 0x3b:		/* DCX SP */
+        SP--;
+        t++;
+        break;
+
+      case 0x3c:		/* INR A */
+        P = A;
+        res = ++A;
+        goto finish_inr;
+
+      case 0x3d:		/* DCR A */
+        P = A;
+        res = --A;
+        goto finish_dcr;
+
+      case 0x3e:		/* MVI A,n */
+        A = memrdr(PC++);
+        t += 3;
+        break;
+
+      case 0x3f:		/* CMC */
+        F ^= C_FLAG;
+        /* S_FLAG, Z_FLAG, H_FLAG, and P_FLAG unchanged */
+        break;
+
+      case 0x41:		/* MOV B,C */
+        B = C;
+        t++;
+        break;
+
+      case 0x42:		/* MOV B,D */
+        B = D;
+        t++;
+        break;
+
+      case 0x43:		/* MOV B,E */
+        B = E;
+        t++;
+        break;
+
+      case 0x44:		/* MOV B,H */
+        B = H;
+        t++;
+        break;
+
+      case 0x45:		/* MOV B,L */
+        B = L;
+        t++;
+        break;
+
+      case 0x46:		/* MOV B,M */
+        B = memrdr(HL);
+        t += 3;
+        break;
+
+      case 0x47:		/* MOV B,A */
+        B = A;
+        t++;
+        break;
+
+      case 0x48:		/* MOV C,B */
+        C = B;
+        t++;
+        break;
+
+      case 0x4a:		/* MOV C,D */
+        C = D;
+        t++;
+        break;
+
+      case 0x4b:		/* MOV C,E */
+        C = E;
+        t++;
+        break;
+
+      case 0x4c:		/* MOV C,H */
+        C = H;
+        t++;
+        break;
+
+      case 0x4d:		/* MOV C,L */
+        C = L;
+        t++;
+        break;
+
+      case 0x4e:		/* MOV C,M */
+        C = memrdr(HL);
+        t += 3;
+        break;
+
+      case 0x4f:		/* MOV C,A */
+        C = A;
+        t++;
+        break;
+
+      case 0x50:		/* MOV D,B */
+        D = B;
+        t++;
+        break;
+
+      case 0x51:		/* MOV D,C */
+        D = C;
+        t++;
+        break;
+
+      case 0x53:		/* MOV D,E */
+        D = E;
+        t++;
+        break;
+
+      case 0x54:		/* MOV D,H */
+        D = H;
+        t++;
+        break;
+
+      case 0x55:		/* MOV D,L */
+        D = L;
+        t++;
+        break;
+
+      case 0x56:		/* MOV D,M */
+        D = memrdr(HL);
+        t += 3;
+        break;
+
+      case 0x57:		/* MOV D,A */
+        D = A;
+        t++;
+        break;
+
+      case 0x58:		/* MOV E,B */
+        E = B;
+        t++;
+        break;
+
+      case 0x59:		/* MOV E,C */
+        E = C;
+        t++;
+        break;
+
+      case 0x5a:		/* MOV E,D */
+        E = D;
+        t++;
+        break;
+
+      case 0x5c:		/* MOV E,H */
+        E = H;
+        t++;
+        break;
+
+      case 0x5d:		/* MOV E,L */
+        E = L;
+        t++;
+        break;
+
+      case 0x5e:		/* MOV E,M */
+        E = memrdr(HL);
+        t += 3;
+        break;
+
+      case 0x5f:		/* MOV E,A */
+        E = A;
+        t++;
+        break;
+
+      case 0x60:		/* MOV H,B */
+        H = B;
+        t++;
+        break;
+
+      case 0x61:		/* MOV H,C */
+        H = C;
+        t++;
+        break;
+
+      case 0x62:		/* MOV H,D */
+        H = D;
+        t++;
+        break;
+
+      case 0x63:		/* MOV H,E */
+        H = E;
+        t++;
+        break;
+
+      case 0x65:		/* MOV H,L */
+        H = L;
+        t++;
+        break;
+
+      case 0x66:		/* MOV H,M */
+        H = memrdr(HL);
+        t += 3;
+        break;
+
+      case 0x67:		/* MOV H,A */
+        H = A;
+        t++;
+        break;
+
+      case 0x68:		/* MOV L,B */
+        L = B;
+        t++;
+        break;
+
+      case 0x69:		/* MOV L,C */
+        L = C;
+        t++;
+        break;
+
+      case 0x6a:		/* MOV L,D */
+        L = D;
+        t++;
+        break;
+
+      case 0x6b:		/* MOV L,E */
+        L = E;
+        t++;
+        break;
+
+      case 0x6c:		/* MOV L,H */
+        L = H;
+        t++;
+        break;
+
+      case 0x6e:		/* MOV L,M */
+        L = memrdr(HL);
+        t += 3;
+        break;
+
+      case 0x6f:		/* MOV L,A */
+        L = A;
+        t++;
+        break;
+
+      case 0x70:		/* MOV M,B */
+        memwrt(HL, B);
+        t += 3;
+        break;
+
+      case 0x71:		/* MOV M,C */
+        memwrt(HL, C);
+        t += 3;
+        break;
+
+      case 0x72:		/* MOV M,D */
+        memwrt(HL, D);
+        t += 3;
+        break;
+
+      case 0x73:		/* MOV M,E */
+        memwrt(HL, E);
+        t += 3;
+        break;
+
+      case 0x74:		/* MOV M,H */
+        memwrt(HL, H);
+        t += 3;
+        break;
+
+      case 0x75:		/* MOV M,L */
+        memwrt(HL, L);
+        t += 3;
+        break;
+
+      case 0x76:		/* HLT */
+        // cry and die, no interrupts yet
+        State = Halted;
+        t += 3;
+        break;
+
+      case 0x77:		/* MOV M,A */
+        memwrt(HL, A);
+        t += 3;
+        break;
+
+      case 0x78:		/* MOV A,B */
+        A = B;
+        t++;
+        break;
+
+      case 0x79:		/* MOV A,C */
+        A = C;
+        t++;
+        break;
+
+      case 0x7a:		/* MOV A,D */
+        A = D;
+        t++;
+        break;
+
+      case 0x7b:		/* MOV A,E */
+        A = E;
+        t++;
+        break;
+
+      case 0x7c:		/* MOV A,H */
+        A = H;
+        t++;
+        break;
+
+      case 0x7d:		/* MOV A,L */
+        A = L;
+        t++;
+        break;
+
+      case 0x7e:		/* MOV A,M */
+        A = memrdr(HL);
+        t += 3;
+        break;
+
+      case 0x80:		/* ADD B */
+        P = B;
+        res = 0;
+finish_add:
+        res = A + P + res;
+        cout = (A & P) | ((A | P) & ~res);
+        F = ((((cout >> 7) & 1) << C_SHIFT) |
+             (((cout >> 3) & 1) << H_SHIFT) |
+             szp_flags[res]);
+        A = res;
+        break;
+
+      case 0x81:		/* ADD C */
+        P = C;
+        res = 0;
+        goto finish_add;
+
+      case 0x82:		/* ADD D */
+        P = D;
+        res = 0;
+        goto finish_add;
+
+      case 0x83:		/* ADD E */
+        P = E;
+        res = 0;
+        goto finish_add;
+
+      case 0x84:		/* ADD H */
+        P = H;
+        res = 0;
+        goto finish_add;
+
+      case 0x85:		/* ADD L */
+        P = L;
+        res = 0;
+        goto finish_add;
+
+      case 0x86:		/* ADD M */
+        P = memrdr(HL);
+        res = 0;
+        t += 3;
+        goto finish_add;
+
+      case 0x87:		/* ADD A */
+        P = A;
+        res = 0;
+        goto finish_add;
+
+      case 0x88:		/* ADC B */
+        P = B;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_add;
+
+      case 0x89:		/* ADC C */
+        P = C;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_add;
+
+      case 0x8a:		/* ADC D */
+        P = D;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_add;
+
+      case 0x8b:		/* ADC E */
+        P = E;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_add;
+
+      case 0x8c:		/* ADC H */
+        P = H;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_add;
+
+      case 0x8d:		/* ADC L */
+        P = L;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_add;
+
+      case 0x8e:		/* ADC M */
+        P = memrdr(HL);
+        res = (F >> C_SHIFT) & 1;
+        t += 3;
+        goto finish_add;
+
+      case 0x8f:		/* ADC A */
+        P = A;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_add;
+
+      case 0x90:		/* SUB B */
+        P = B;
+        res = 0;
+finish_sub:
+        res = A - P - res;
+        cout = (~A & P) | ((~A | P) & res);
+        F = ((((cout >> 7) & 1) << C_SHIFT) |
+             (((cout >> 3) & 1) << H_SHIFT) |
+             szp_flags[res]);
+        F ^= H_FLAG;
+        A = res;
+        break;
+
+      case 0x91:		/* SUB C */
+        P = C;
+        res = 0;
+        goto finish_sub;
+
+      case 0x92:		/* SUB D */
+        P = D;
+        res = 0;
+        goto finish_sub;
+
+      case 0x93:		/* SUB E */
+        P = E;
+        res = 0;
+        goto finish_sub;
+
+      case 0x94:		/* SUB H */
+        P = H;
+        res = 0;
+        goto finish_sub;
+
+      case 0x95:		/* SUB L */
+        P = L;
+        res = 0;
+        goto finish_sub;
+
+      case 0x96:		/* SUB M */
+        P = memrdr(HL);
+        res = 0;
+        t += 3;
+        goto finish_sub;
+
+      case 0x97:		/* SUB A */
+        F = Z_FLAG | H_FLAG | P_FLAG;
+        /* S_FLAG and C_FLAG cleared */
+        A = 0;
+        break;
+
+      case 0x98:		/* SBB B */
+        P = B;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_sub;
+
+      case 0x99:		/* SBB C */
+        P = C;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_sub;
+
+      case 0x9a:		/* SBB D */
+        P = D;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_sub;
+
+      case 0x9b:		/* SBB E */
+        P = E;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_sub;
+
+      case 0x9c:		/* SBB H */
+        P = H;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_sub;
+
+      case 0x9d:		/* SBB L */
+        P = L;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_sub;
+
+      case 0x9e:		/* SBB M */
+        P = memrdr(HL);
+        res = (F >> C_SHIFT) & 1;
+        t += 3;
+        goto finish_sub;
+
+      case 0x9f:		/* SBB A */
+        P = A;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_sub;
+
+      case 0xa0:		/* ANA B */
+        P = B;
+finish_ana:
+        res = A & P;
 #ifdef AMD8080
-      F = szp_flags[res];
-      /* H_FLAG and C_FLAG cleared */
+        F = szp_flags[res];
+        /* H_FLAG and C_FLAG cleared */
 #else
-      F = (((((A | P) >> 3) & 1) << H_SHIFT) |
-           szp_flags[res]);
-      /* C_FLAG cleared */
+        F = (((((A | P) >> 3) & 1) << H_SHIFT) |
+             szp_flags[res]);
+        /* C_FLAG cleared */
 #endif
-      A = res;
-      break;
+        A = res;
+        break;
 
-    case 0xa1:			/* ANA C */
-      P = C;
-      goto finish_ana;
+      case 0xa1:		/* ANA C */
+        P = C;
+        goto finish_ana;
 
-    case 0xa2:			/* ANA D */
-      P = D;
-      goto finish_ana;
+      case 0xa2:		/* ANA D */
+        P = D;
+        goto finish_ana;
 
-    case 0xa3:			/* ANA E */
-      P = E;
-      goto finish_ana;
+      case 0xa3:		/* ANA E */
+        P = E;
+        goto finish_ana;
 
-    case 0xa4:			/* ANA H */
-      P = H;
-      goto finish_ana;
+      case 0xa4:		/* ANA H */
+        P = H;
+        goto finish_ana;
 
-    case 0xa5:			/* ANA L */
-      P = L;
-      goto finish_ana;
+      case 0xa5:		/* ANA L */
+        P = L;
+        goto finish_ana;
 
-    case 0xa6:			/* ANA M */
-      P = memrdr((H << 8) | L);
-      t += 3;
-      goto finish_ana;
+      case 0xa6:		/* ANA M */
+        P = memrdr(HL);
+        t += 3;
+        goto finish_ana;
 
-    case 0xa7:			/* ANA A */
-      P = A;
-      goto finish_ana;
+      case 0xa7:		/* ANA A */
+        P = A;
+        goto finish_ana;
 
-    case 0xa8:			/* XRA B */
-      P = B;
-    finish_xra:
-      res = A ^ P;
-      F = szp_flags[res];
-      /* H_FLAG and C_FLAG cleared */
-      A = res;
-      break;
+      case 0xa8:		/* XRA B */
+        P = B;
+finish_xra:
+        res = A ^ P;
+        F = szp_flags[res];
+        /* H_FLAG and C_FLAG cleared */
+        A = res;
+        break;
 
-    case 0xa9:			/* XRA C */
-      P = C;
-      goto finish_xra;
+      case 0xa9:		/* XRA C */
+        P = C;
+        goto finish_xra;
 
-    case 0xaa:			/* XRA D */
-      P = D;
-      goto finish_xra;
+      case 0xaa:		/* XRA D */
+        P = D;
+        goto finish_xra;
 
-    case 0xab:			/* XRA E */
-      P = E;
-      goto finish_xra;
+      case 0xab:		/* XRA E */
+        P = E;
+        goto finish_xra;
 
-    case 0xac:			/* XRA H */
-      P = H;
-      goto finish_xra;
+      case 0xac:		/* XRA H */
+        P = H;
+        goto finish_xra;
 
-    case 0xad:			/* XRA L */
-      P = L;
-      goto finish_xra;
+      case 0xad:		/* XRA L */
+        P = L;
+        goto finish_xra;
 
-    case 0xae:			/* XRA M */
-      P = memrdr((H << 8) | L);
-      t += 3;
-      goto finish_xra;
+      case 0xae:		/* XRA M */
+        P = memrdr(HL);
+        t += 3;
+        goto finish_xra;
 
-    case 0xaf:			/* XRA A */
-      F = Z_FLAG | P_FLAG;
-      /* S_FLAG, H_FLAG, and C_FLAG cleared */
-      A = 0;
-      break;
+      case 0xaf:		/* XRA A */
+        F = Z_FLAG | P_FLAG;
+        /* S_FLAG, H_FLAG, and C_FLAG cleared */
+        A = 0;
+        break;
 
-    case 0xb0:			/* ORA B */
-      P = B;
-    finish_ora:
-      res = A | P;
-      F = szp_flags[res];
-      /* H_FLAG and C_FLAG cleared */
-      A = res;
-      break;
+      case 0xb0:		/* ORA B */
+        P = B;
+finish_ora:
+        res = A | P;
+        F = szp_flags[res];
+        /* H_FLAG and C_FLAG cleared */
+        A = res;
+        break;
 
-    case 0xb1:			/* ORA C */
-      P = C;
-      goto finish_ora;
+      case 0xb1:		/* ORA C */
+        P = C;
+        goto finish_ora;
 
-    case 0xb2:			/* ORA D */
-      P = D;
-      goto finish_ora;
+      case 0xb2:		/* ORA D */
+        P = D;
+        goto finish_ora;
 
-    case 0xb3:			/* ORA E */
-      P = E;
-      goto finish_ora;
+      case 0xb3:		/* ORA E */
+        P = E;
+        goto finish_ora;
 
-    case 0xb4:			/* ORA H */
-      P = H;
-      goto finish_ora;
+      case 0xb4:		/* ORA H */
+        P = H;
+        goto finish_ora;
 
-    case 0xb5:			/* ORA L */
-      P = L;
-      goto finish_ora;
+      case 0xb5:		/* ORA L */
+        P = L;
+        goto finish_ora;
 
-    case 0xb6:			/* ORA M */
-      P = memrdr((H << 8) | L);
-      t += 3;
-      goto finish_ora;
+      case 0xb6:		/* ORA M */
+        P = memrdr(HL);
+        t += 3;
+        goto finish_ora;
 
-    case 0xb7:			/* ORA A */
-      F = szp_flags[A];
-      /* H_FLAG and C_FLAG cleared */
-      break;
+      case 0xb7:		/* ORA A */
+        F = szp_flags[A];
+        /* H_FLAG and C_FLAG cleared */
+        break;
 
-    case 0xb8:			/* CMP B */
-      P = B;
-    finish_cmp:
-      res = A - P;
-      cout = (~A & P) | ((~A | P) & res);
-      F = ((((cout >> 7) & 1) << C_SHIFT) |
-           (((cout >> 3) & 1) << H_SHIFT) |
-           szp_flags[res]);
-      F ^= H_FLAG;
-      break;
+      case 0xb8:		/* CMP B */
+        P = B;
+finish_cmp:
+        res = A - P;
+        cout = (~A & P) | ((~A | P) & res);
+        F = ((((cout >> 7) & 1) << C_SHIFT) |
+             (((cout >> 3) & 1) << H_SHIFT) |
+             szp_flags[res]);
+        F ^= H_FLAG;
+        break;
 
-    case 0xb9:			/* CMP C */
-      P = C;
-      goto finish_cmp;
+      case 0xb9:		/* CMP C */
+        P = C;
+        goto finish_cmp;
 
-    case 0xba:			/* CMP D */
-      P = D;
-      goto finish_cmp;
+      case 0xba:		/* CMP D */
+        P = D;
+        goto finish_cmp;
 
-    case 0xbb:			/* CMP E */
-      P = E;
-      goto finish_cmp;
+      case 0xbb:		/* CMP E */
+        P = E;
+        goto finish_cmp;
 
-    case 0xbc:			/* CMP H */
-      P = H;
-      goto finish_cmp;
+      case 0xbc:		/* CMP H */
+        P = H;
+        goto finish_cmp;
 
-    case 0xbd:			/* CMP L */
-      P = L;
-      goto finish_cmp;
+      case 0xbd:		/* CMP L */
+        P = L;
+        goto finish_cmp;
 
-    case 0xbe:			/* CMP M */
-      P = memrdr((H << 8) | L);
-      t += 3;
-      goto finish_cmp;
+      case 0xbe:		/* CMP M */
+        P = memrdr(HL);
+        t += 3;
+        goto finish_cmp;
 
-    case 0xbf:			/* CMP A */
-      F = Z_FLAG | H_FLAG | P_FLAG;
-      /* S_FLAG and C_FLAG cleared */
-      break;
+      case 0xbf:		/* CMP A */
+        F = Z_FLAG | H_FLAG | P_FLAG;
+        /* S_FLAG and C_FLAG cleared */
+        break;
 
-    case 0xc0:			/* RNZ */
-      res = !(F & Z_FLAG);
-    finish_retc:
-      t++;
-      if (res)
-        goto finish_ret;
-      break;
+      case 0xc0:		/* RNZ */
+        res = !(F & Z_FLAG);
+finish_retc:
+        t++;
+        if (res)
+          goto finish_ret;
+        break;
 
-    case 0xc1:			/* POP B */
-      C = memrdr(SP8++);
-      B = memrdr(SP8++);
-      t += 6;
-      break;
+      case 0xc1:		/* POP B */
+        C = memrdr(SP++);
+        B = memrdr(SP++);
+        t += 6;
+        break;
 
-    case 0xc2:			/* JNZ nn */
-      res = !(F & Z_FLAG);
-    finish_jmpc:
-      W = memrdr(PC8++);
-      W |= memrdr(PC8++) << 8;
-      t += 6;
-      if (res)
-        PC8 = W;
-      break;
+      case 0xc2:		/* JNZ nn */
+        res = !(F & Z_FLAG);
+finish_jmpc:
+        WL = memrdr(PC++);
+        WH = memrdr(PC++);
+        t += 6;
+        if (res)
+          PC = W;
+        break;
 
-    case 0xc3:			/* JMP nn */
-    case 0xcb:			/* JMP* nn */
-      W = memrdr(PC8++);
-      W |= memrdr(PC8) << 8;
-      t += 6;
-      PC8 = W;
-      break;
+      case 0xc3:		/* JMP nn */
+      case 0xcb:		/* JMP* nn */
+        WL = memrdr(PC++);
+        WH = memrdr(PC);
+        t += 6;
+        PC = W;
+        break;
 
-    case 0xc4:			/* CNZ nn */
-      res = !(F & Z_FLAG);
-    finish_callc:
-      W = memrdr(PC8++);
-      W |= memrdr(PC8++) << 8;
-      t += 7;
-      if (res)
+      case 0xc4:		/* CNZ nn */
+        res = !(F & Z_FLAG);
+finish_callc:
+        WL = memrdr(PC++);
+        WH = memrdr(PC++);
+        t += 7;
+        if (res)
+          goto finish_call;
+        break;
+
+      case 0xc5:		/* PUSH B */
+        memwrt(--SP, B);
+        memwrt(--SP, C);
+        t += 7;
+        break;
+
+      case 0xc6:		/* ADI n */
+        P = memrdr(PC++);
+        res = 0;
+        t += 3;
+        goto finish_add;
+
+      case 0xc7:		/* RST 0 */
+        W = 0;
+        t++;
         goto finish_call;
-      break;
 
-    case 0xc5:			/* PUSH B */
-      memwrt(--SP8, B);
-      memwrt(--SP8, C);
-      t += 7;
-      break;
+      case 0xc8:		/* RZ */
+        res = F & Z_FLAG;
+        goto finish_retc;
 
-    case 0xc6:			/* ADI n */
-      P = memrdr(PC8++);
-      t += 3;
-      goto finish_add;
+      case 0xc9:		/* RET */
+      case 0xd9:		/* RET* */
+finish_ret:
+        WL = memrdr(SP++);
+        WH = memrdr(SP++);
+        t += 6;
+        PC = W;
+        break;
 
-    case 0xc7:			/* RST 0 */
-      W = 0;
-      t++;
-      goto finish_call;
+      case 0xca:		/* JZ nn */
+        res = F & Z_FLAG;
+        goto finish_jmpc;
 
-    case 0xc8:			/* RZ */
-      res = F & Z_FLAG;
-      goto finish_retc;
+      case 0xcc:		/* CZ nn */
+        res = F & Z_FLAG;
+        goto finish_callc;
 
-    case 0xc9:			/* RET */
-    case 0xd9:			/* RET* */
-    finish_ret:
-      W = memrdr(SP8++);
-      W |= memrdr(SP8++) << 8;
-      t += 6;
-      PC8 = W;
-      break;
+      case 0xcd:		/* CALL nn */
+      case 0xdd:		/* CALL* nn */
+      case 0xed:		/* CALL* nn */
+      case 0xfd:		/* CALL* nn */
+        WL = memrdr(PC++);
+        WH = memrdr(PC++);
+        t += 7;
+finish_call:
+        memwrt(--SP, PCH);
+        memwrt(--SP, PCL);
+        t += 6;
+        PC = W;
+        break;
 
-    case 0xca:			/* JZ nn */
-      res = F & Z_FLAG;
-      goto finish_jmpc;
+      case 0xce:		/* ACI n */
+        P = memrdr(PC++);
+        res = (F >> C_SHIFT) & 1;
+        t += 3;
+        goto finish_add;
 
-    case 0xcc:			/* CZ nn */
-      res = F & Z_FLAG;
-      goto finish_callc;
+      case 0xcf:		/* RST 1 */
+        W = 0x08;
+        t++;
+        goto finish_call;
 
-    case 0xcd:			/* CALL nn */
-    case 0xdd:			/* CALL* nn */
-    case 0xed:			/* CALL* nn */
-    case 0xfd:			/* CALL* nn */
-      W = memrdr(PC8++);
-      W |= memrdr(PC8++) << 8;
-      t += 7;
-    finish_call:
-      memwrt(--SP8, PC8 >> 8);
-      memwrt(--SP8, PC8 & 0xff);
-      t += 6;
-      PC8 = W;
-      break;
+      case 0xd0:		/* RNC */
+        res = !(F & C_FLAG);
+        goto finish_retc;
 
-    case 0xce:			/* ACI n */
-      P = memrdr(PC8++);
-      t += 3;
-      goto finish_adc;
+      case 0xd1:		/* POP D */
+        E = memrdr(SP++);
+        D = memrdr(SP++);
+        t += 6;
+        break;
 
-    case 0xcf:			/* RST 1 */
-      W = 0x08;
-      t++;
-      goto finish_call;
+      case 0xd2:		/* JNC nn */
+        res = !(F & C_FLAG);
+        goto finish_jmpc;
 
-    case 0xd0:			/* RNC */
-      res = !(F & C_FLAG);
-      goto finish_retc;
+      case 0xd3:		/* OUT n */
+        P = memrdr(PC++);
+        io_out(P, P, A);
+        t += 6;
+        break;
 
-    case 0xd1:			/* POP D */
-      E = memrdr(SP8++);
-      D = memrdr(SP8++);
-      t += 6;
-      break;
+      case 0xd4:		/* CNC nn */
+        res = !(F & C_FLAG);
+        goto finish_callc;
 
-    case 0xd2:			/* JNC nn */
-      res = !(F & C_FLAG);
-      goto finish_jmpc;
+      case 0xd5:		/* PUSH D */
+        memwrt(--SP, D);
+        memwrt(--SP, E);
+        t += 7;
+        break;
 
-    case 0xd3:			/* OUT n */
-      P = memrdr(PC8++);
-      io_out(P, P, A);
-      t += 6;
-      break;
+      case 0xd6:		/* SUI n */
+        P = memrdr(PC++);
+        res = 0;
+        t += 3;
+        goto finish_sub;
 
-    case 0xd4:			/* CNC nn */
-      res = !(F & C_FLAG);
-      goto finish_callc;
+      case 0xd7:		/* RST 2 */
+        W = 0x10;
+        t++;
+        goto finish_call;
 
-    case 0xd5:			/* PUSH D */
-      memwrt(--SP8, D);
-      memwrt(--SP8, E);
-      t += 7;
-      break;
+      case 0xd8:		/* RC */
+        res = F & C_FLAG;
+        goto finish_retc;
 
-    case 0xd6:			/* SUI n */
-      P = memrdr(PC8++);
-      t += 3;
-      goto finish_sub;
+      case 0xda:		/* JC nn */
+        res = F & C_FLAG;
+        goto finish_jmpc;
 
-    case 0xd7:			/* RST 2 */
-      W = 0x10;
-      t++;
-      goto finish_call;
+      case 0xdb:		/* IN n */
+        P = memrdr(PC++);
+        A = io_in(P, P);
+        t += 6;
+        break;
 
-    case 0xd8:			/* RC */
-      res = F & C_FLAG;
-      goto finish_retc;
+      case 0xdc:		/* CC nn */
+        res = F & C_FLAG;
+        goto finish_callc;
 
-    case 0xda:			/* JC nn */
-      res = F & C_FLAG;
-      goto finish_jmpc;
+      case 0xde:		/* SBI n */
+        P = memrdr(PC++);
+        res = (F >> C_SHIFT) & 1;
+        t += 3;
+        goto finish_sub;
 
-    case 0xdb:			/* IN n */
-      P = memrdr(PC8++);
-      A = io_in(P, P);
-      t += 6;
-      break;
+      case 0xdf:		/* RST 3 */
+        W = 0x18;
+        t++;
+        goto finish_call;
 
-    case 0xdc:			/* CC nn */
-      res = F & C_FLAG;
-      goto finish_callc;
+      case 0xe0:		/* RPO */
+        res = !(F & P_FLAG);
+        goto finish_retc;
 
-    case 0xde:			/* SBI n */
-      P = memrdr(PC8++);
-      t += 3;
-      goto finish_sbb;
+      case 0xe1:		/* POP H */
+        L = memrdr(SP++);
+        H = memrdr(SP++);
+        t += 6;
+        break;
 
-    case 0xdf:			/* RST 3 */
-      W = 0x18;
-      t++;
-      goto finish_call;
+      case 0xe2:		/* JPO nn */
+        res = !(F & P_FLAG);
+        goto finish_jmpc;
 
-    case 0xe0:			/* RPO */
-      res = !(F & P_FLAG);
-      goto finish_retc;
+      case 0xe3:		/* XTHL */
+        P = memrdr(SP);
+        memwrt(SP, L);
+        L = P;
+        P = memrdr(SP + 1);
+        memwrt(SP + 1, H);
+        H = P;
+        t += 14;
+        break;
 
-    case 0xe1:			/* POP H */
-      L = memrdr(SP8++);
-      H = memrdr(SP8++);
-      t += 6;
-      break;
+      case 0xe4:		/* CPO nn */
+        res = !(F & P_FLAG);
+        goto finish_callc;
 
-    case 0xe2:			/* JPO nn */
-      res = !(F & P_FLAG);
-      goto finish_jmpc;
+      case 0xe5:		/* PUSH H */
+        memwrt(--SP, H);
+        memwrt(--SP, L);
+        t += 7;
+        break;
 
-    case 0xe3:			/* XTHL */
-      P = memrdr(SP8);
-      memwrt(SP8, L);
-      L = P;
-      P = memrdr(SP8 + 1);
-      memwrt(SP8 + 1, H);
-      H = P;
-      t += 14;
-      break;
+      case 0xe6:		/* ANI n */
+        P = memrdr(PC++);
+        t += 3;
+        goto finish_ana;
 
-    case 0xe4:			/* CPO nn */
-      res = !(F & P_FLAG);
-      goto finish_callc;
+      case 0xe7:		/* RST 4 */
+        W = 0x20;
+        t++;
+        goto finish_call;
 
-    case 0xe5:			/* PUSH H */
-      memwrt(--SP8, H);
-      memwrt(--SP8, L);
-      t += 7;
-      break;
+      case 0xe8:		/* RPE */
+        res = F & P_FLAG;
+        goto finish_retc;
 
-    case 0xe6:			/* ANI n */
-      P = memrdr(PC8++);
-      t += 3;
-      goto finish_ana;
+      case 0xe9:		/* PCHL */
+        PC = HL;
+        t++;
+        break;
 
-    case 0xe7:			/* RST 4 */
-      W = 0x20;
-      t++;
-      goto finish_call;
+      case 0xea:		/* JPE nn */
+        res = F & P_FLAG;
+        goto finish_jmpc;
 
-    case 0xe8:			/* RPE */
-      res = F & P_FLAG;
-      goto finish_retc;
+      case 0xeb:		/* XCHG */
+        P = D;
+        D = H;
+        H = P;
+        P = E;
+        E = L;
+        L = P;
+        break;
 
-    case 0xe9:			/* PCHL */
-      PC8 = (H << 8) | L;
-      t++;
-      break;
+      case 0xec:		/* CPE nn */
+        res = F & P_FLAG;
+        goto finish_callc;
 
-    case 0xea:			/* JPE nn */
-      res = F & P_FLAG;
-      goto finish_jmpc;
+      case 0xee:		/* XRI n */
+        P = memrdr(PC++);
+        t += 3;
+        goto finish_xra;
 
-    case 0xeb:			/* XCHG */
-      P = D;
-      D = H;
-      H = P;
-      P = E;
-      E = L;
-      L = P;
-      break;
+      case 0xef:		/* RST 5 */
+        W = 0x28;
+        t++;
+        goto finish_call;
 
-    case 0xec:			/* CPE nn */
-      res = F & P_FLAG;
-      goto finish_callc;
+      case 0xf0:		/* RP */
+        res = !(F & S_FLAG);
+        goto finish_retc;
 
-    case 0xee:			/* XRI n */
-      P = memrdr(PC8++);
-      t += 3;
-      goto finish_xra;
+      case 0xf1:		/* POP PSW */
+        F = memrdr(SP++);
+        A = memrdr(SP++);
+        t += 6;
+        break;
 
-    case 0xef:			/* RST 5 */
-      W = 0x28;
-      t++;
-      goto finish_call;
+      case 0xf2:		/* JP nn */
+        res = !(F & S_FLAG);
+        goto finish_jmpc;
 
-    case 0xf0:			/* RP */
-      res = !(F & S_FLAG);
-      goto finish_retc;
+      case 0xf3:		/* DI */
+        IFF = 0;
+        break;
 
-    case 0xf1:			/* POP PSW */
-      F = memrdr(SP8++);
-      A = memrdr(SP8++);
-      t += 6;
-      break;
+      case 0xf4:		/* CP nn */
+        res = !(F & S_FLAG);
+        goto finish_callc;
 
-    case 0xf2:			/* JP nn */
-      res = !(F & S_FLAG);
-      goto finish_jmpc;
+      case 0xf5:		/* PUSH PSW */
+        memwrt(--SP, A);
+        memwrt(--SP, ((F & ~(Y_FLAG | X_FLAG)) | N_FLAG));
+        t += 7;
+        break;
 
-    case 0xf3:			/* DI */
-      IFF = 0;
-      break;
+      case 0xf6:		/* ORI n */
+        P = memrdr(PC++);
+        t += 3;
+        goto finish_ora;
 
-    case 0xf4:			/* CP nn */
-      res = !(F & S_FLAG);
-      goto finish_callc;
+      case 0xf7:		/* RST 6 */
+        W = 0x30;
+        t++;
+        goto finish_call;
 
-    case 0xf5:			/* PUSH PSW */
-      memwrt(--SP8, A);
-      memwrt(--SP8, ((F & ~(Y_FLAG | X_FLAG)) | N_FLAG));
-      t += 7;
-      break;
+      case 0xf8:		/* RM */
+        res = F & S_FLAG;
+        goto finish_retc;
 
-    case 0xf6:			/* ORI n */
-      P = memrdr(PC8++);
-      t += 3;
-      goto finish_ora;
+      case 0xf9:		/* SPHL */
+        SP = HL;
+        t++;
+        break;
 
-    case 0xf7:			/* RST 6 */
-      W = 0x30;
-      t++;
-      goto finish_call;
+      case 0xfa:		/* JM nn */
+        res = F & S_FLAG;
+        goto finish_jmpc;
 
-    case 0xf8:			/* RM */
-      res = F & S_FLAG;
-      goto finish_retc;
+      case 0xfb:		/* EI */
+        IFF = 3;
+        // int_protection = 1;	/* protect next instruction */
+        break;
 
-    case 0xf9:			/* SPHL */
-      SP8 = (H << 8) | L;
-      t++;
-      break;
+      case 0xfc:		/* CM nn */
+        res = F & S_FLAG;
+        goto finish_callc;
 
-    case 0xfa:			/* JM nn */
-      res = F & S_FLAG;
-      goto finish_jmpc;
+      case 0xfe:		/* CPI n */
+        P = memrdr(PC++);
+        t += 3;
+        goto finish_cmp;
 
-    case 0xfb:			/* EI */
-      IFF = 3;
-      // int_protection = 1;	/* protect next instruction */
-      break;
-
-    case 0xfc:			/* CM nn */
-      res = F & S_FLAG;
-      goto finish_callc;
-
-    case 0xfe:			/* CPI n */
-      P = memrdr(PC8++);
-      t += 3;
-      goto finish_cmp;
-
-    case 0xff:			/* RST 7 */
-      W = 0x38;
-      t++;
-      goto finish_call;
+      case 0xff:		/* RST 7 */
+        W = 0x38;
+        t++;
+        goto finish_call;
     }
 
-    tstates += t; // account for the executed instruction
+    tstates += t;  // account for the executed instruction
 
   } while (State == Running);
 
-  cpu_state->A = A;
-  cpu_state->B = B;
-  cpu_state->C = C;
-  cpu_state->D = D;
-  cpu_state->E = E;
-  cpu_state->H = H;
-  cpu_state->L = L;
-  cpu_state->F = F;
-  cpu_state->IFF = IFF;
-  cpu_state->PC8 = PC8;
-  cpu_state->SP8 = SP8;
+  *cpu_state = cpu_regs;
+
+#undef W
+#undef WH
+#undef WL
+
+#undef AF
+#undef A
+#undef F
+#undef BC
+#undef B
+#undef C
+#undef DE
+#undef D
+#undef E
+#undef HL
+#undef H
+#undef L
+#undef SP
+#undef SPH
+#undef SPL
+#undef PC
+#undef PCH
+#undef PCL
+#undef IFF
+
+#pragma pop_macro("F")
+#pragma pop_macro("SP")
+#pragma pop_macro("PC")
 }
 
 // interrupt handler for break switch, stops CPU
@@ -1579,29 +1647,29 @@ void loop()
   
   // print register dump
   Serial.println(F("PC\tA\tSZHPC\tB:C\tD:E\tH:L\tSP"));
-  Serial.print(cpu_state.PC8, HEX);
+  Serial.print(cpu_state.pc.w, HEX);
   Serial.print(F("\t"));
-  Serial.print(cpu_state.A, HEX);
+  Serial.print(cpu_state.af.h, HEX);
   Serial.print(F("\t"));
-  Serial.print(cpu_state.F & S_FLAG ? 1 : 0, DEC);
-  Serial.print(cpu_state.F & Z_FLAG ? 1 : 0, DEC);
-  Serial.print(cpu_state.F & H_FLAG ? 1 : 0, DEC);
-  Serial.print(cpu_state.F & P_FLAG ? 1 : 0, DEC);
-  Serial.print(cpu_state.F & C_FLAG ? 1 : 0, DEC);
+  Serial.print(cpu_state.af.l & S_FLAG ? 1 : 0, DEC);
+  Serial.print(cpu_state.af.l & Z_FLAG ? 1 : 0, DEC);
+  Serial.print(cpu_state.af.l & H_FLAG ? 1 : 0, DEC);
+  Serial.print(cpu_state.af.l & P_FLAG ? 1 : 0, DEC);
+  Serial.print(cpu_state.af.l & C_FLAG ? 1 : 0, DEC);
   Serial.print(F("\t"));
-  Serial.print(cpu_state.B, HEX);
+  Serial.print(cpu_state.bc.h, HEX);
   Serial.print(F(":"));
-  Serial.print(cpu_state.C, HEX);
+  Serial.print(cpu_state.bc.l, HEX);
   Serial.print(F("\t"));
-  Serial.print(cpu_state.D, HEX);
+  Serial.print(cpu_state.de.h, HEX);
   Serial.print(F(":"));
-  Serial.print(cpu_state.E, HEX);
+  Serial.print(cpu_state.de.l, HEX);
   Serial.print(F("\t"));
-  Serial.print(cpu_state.H, HEX);
+  Serial.print(cpu_state.hl.h, HEX);
   Serial.print(F(":"));
-  Serial.print(cpu_state.L, HEX);
+  Serial.print(cpu_state.hl.l, HEX);
   Serial.print(F("\t"));
-  Serial.print(cpu_state.SP8, HEX);
+  Serial.print(cpu_state.sp.w, HEX);
   Serial.println();
 
   // print some execution statistics

--- a/arduino_8080.ino.z80
+++ b/arduino_8080.ino.z80
@@ -41,12 +41,48 @@ typedef unsigned int  WORD;
 #include "iosim.h"
 #include "config.h"
 
+#if _BYTE_ORDER == _LITTLE_ENDIAN
+struct cpu_reg {
+  union {
+    struct {
+      BYTE l;
+      BYTE h;
+    };
+    WORD w;
+  };
+};
+#elif _BYTE_ORDER == _BIG_ENDIAN
+struct cpu_reg {
+  union {
+    struct {
+      BYTE h;
+      BYTE l;
+    };
+    WORD w;
+  };
+};
+#else
+#error "Unsupported byte order"
+#endif
+
 // Z80 CPU state
 struct cpu_state {
-  BYTE A, B, C, D, E, H, L, F, IFF;
-  BYTE A_, B_, C_, D_, E_, H_, L_, F_, I, R, R_;
-  WORD IX, IY;
-  WORD PC8, SP8; // funny names because SP already is a macro here
+  struct cpu_reg af;	/* primary registers */
+  struct cpu_reg bc;
+  struct cpu_reg de;
+  struct cpu_reg hl;
+  struct cpu_reg sp;	/* stack pointer */
+  struct cpu_reg pc;	/* program counter */
+  struct cpu_reg af_;	/* Z80 alternate registers */
+  struct cpu_reg bc_;
+  struct cpu_reg de_;
+  struct cpu_reg hl_;
+  struct cpu_reg ix;	/* Z80 index registers */
+  struct cpu_reg iy;
+  BYTE i;		/* Z80 interrupt register */
+  BYTE r;		/* Z80 refresh register (7-bit counter) */
+  BYTE r_;		/* 8th bit of R (can be loaded with LD R,A) */
+  BYTE iff;		/* interupt flags */
 } cpu_state;
 
 // other global variables
@@ -62,38 +98,38 @@ SdFat32 SD;
 #define Z Z_FLAG
 #define P P_FLAG
 static const BYTE szp_flags[256] = {
-/*00*/ Z | P,     _,     _,     P,     _,     P,     P,     _,
-/*08*/     _,     P,     P,     _,     P,     _,     _,     P,
-/*10*/     _,     P,     P,     _,     P,     _,     _,     P,
-/*18*/     P,     _,     _,     P,     _,     P,     P,     _,
-/*20*/     _,     P,     P,     _,     P,     _,     _,     P,
-/*28*/     P,     _,     _,     P,     _,     P,     P,     _,
-/*30*/     P,     _,     _,     P,     _,     P,     P,     _,
-/*38*/     _,     P,     P,     _,     P,     _,     _,     P,
-/*40*/     _,     P,     P,     _,     P,     _,     _,     P,
-/*48*/     P,     _,     _,     P,     _,     P,     P,     _,
-/*50*/     P,     _,     _,     P,     _,     P,     P,     _,
-/*58*/     _,     P,     P,     _,     P,     _,     _,     P,
-/*60*/     P,     _,     _,     P,     _,     P,     P,     _,
-/*68*/     _,     P,     P,     _,     P,     _,     _,     P,
-/*70*/     _,     P,     P,     _,     P,     _,     _,     P,
-/*78*/     P,     _,     _,     P,     _,     P,     P,     _,
-/*80*/     S, S | P, S | P,     S, S | P,     S,     S, S | P,
-/*88*/ S | P,     S,     S, S | P,     S, S | P, S | P,     S,
-/*90*/ S | P,     S,     S, S | P,     S, S | P, S | P,     S,
-/*98*/     S, S | P, S | P,     S, S | P,     S,     S, S | P,
-/*a0*/ S | P,     S,     S, S | P,     S, S | P, S | P,     S,
-/*a8*/     S, S | P, S | P,     S, S | P,     S,     S, S | P,
-/*b0*/     S, S | P, S | P,     S, S | P,     S,     S, S | P,
-/*b8*/ S | P,     S,     S, S | P,     S, S | P, S | P,     S,
-/*c0*/ S | P,     S,     S, S | P,     S, S | P, S | P,     S,
-/*c8*/     S, S | P, S | P,     S, S | P,     S,     S, S | P,
-/*d0*/     S, S | P, S | P,     S, S | P,     S,     S, S | P,
-/*d8*/ S | P,     S,     S, S | P,     S, S | P, S | P,     S,
-/*e0*/     S, S | P, S | P,     S, S | P,     S,     S, S | P,
-/*e8*/ S | P,     S,     S, S | P,     S, S | P, S | P,     S,
-/*f0*/ S | P,     S,     S, S | P,     S, S | P, S | P,     S,
-/*f8*/     S, S | P, S | P,     S, S | P,     S,     S, S | P
+  /*00*/ Z|P,   _,   _,   P,   _,   P,   P,   _,
+  /*08*/   _,   P,   P,   _,   P,   _,   _,   P,
+  /*10*/   _,   P,   P,   _,   P,   _,   _,   P,
+  /*18*/   P,   _,   _,   P,   _,   P,   P,   _,
+  /*20*/   _,   P,   P,   _,   P,   _,   _,   P,
+  /*28*/   P,   _,   _,   P,   _,   P,   P,   _,
+  /*30*/   P,   _,   _,   P,   _,   P,   P,   _,
+  /*38*/   _,   P,   P,   _,   P,   _,   _,   P,
+  /*40*/   _,   P,   P,   _,   P,   _,   _,   P,
+  /*48*/   P,   _,   _,   P,   _,   P,   P,   _,
+  /*50*/   P,   _,   _,   P,   _,   P,   P,   _,
+  /*58*/   _,   P,   P,   _,   P,   _,   _,   P,
+  /*60*/   P,   _,   _,   P,   _,   P,   P,   _,
+  /*68*/   _,   P,   P,   _,   P,   _,   _,   P,
+  /*70*/   _,   P,   P,   _,   P,   _,   _,   P,
+  /*78*/   P,   _,   _,   P,   _,   P,   P,   _,
+  /*80*/   S, S|P, S|P,   S, S|P,   S,   S, S|P,
+  /*88*/ S|P,   S,   S, S|P,   S, S|P, S|P,   S,
+  /*90*/ S|P,   S,   S, S|P,   S, S|P, S|P,   S,
+  /*98*/   S, S|P, S|P,   S, S|P,   S,   S, S|P,
+  /*a0*/ S|P,   S,   S, S|P,   S, S|P, S|P,   S,
+  /*a8*/   S, S|P, S|P,   S, S|P,   S,   S, S|P,
+  /*b0*/   S, S|P, S|P,   S, S|P,   S,   S, S|P,
+  /*b8*/ S|P,   S,   S, S|P,   S, S|P, S|P,   S,
+  /*c0*/ S|P,   S,   S, S|P,   S, S|P, S|P,   S,
+  /*c8*/   S, S|P, S|P,   S, S|P,   S,   S, S|P,
+  /*d0*/   S, S|P, S|P,   S, S|P,   S,   S, S|P,
+  /*d8*/ S|P,   S,   S, S|P,   S, S|P, S|P,   S,
+  /*e0*/   S, S|P, S|P,   S, S|P,   S,   S, S|P,
+  /*e8*/ S|P,   S,   S, S|P,   S, S|P, S|P,   S,
+  /*f0*/ S|P,   S,   S, S|P,   S, S|P, S|P,   S,
+  /*f8*/   S, S|P, S|P,   S, S|P,   S,   S, S|P
 };
 #undef _
 #undef S
@@ -106,27 +142,19 @@ static const BYTE szp_flags[256] = {
 // beginning, which is not the case with the silicon.
 static void init_cpu(struct cpu_state *cpu_state)
 {
-  cpu_state->PC8 = 0;
-  cpu_state->SP8 = random(65535);
-  cpu_state->A = random(255);
-  cpu_state->B = random(255);
-  cpu_state->C = random(255);
-  cpu_state->D = random(255);
-  cpu_state->E = random(255);
-  cpu_state->H = random(255);
-  cpu_state->L = random(255);
-  cpu_state->F = random(255);
-  cpu_state->A_ = random(255);
-  cpu_state->B_ = random(255);
-  cpu_state->C_ = random(255);
-  cpu_state->D_ = random(255);
-  cpu_state->E_ = random(255);
-  cpu_state->H_ = random(255);
-  cpu_state->L_ = random(255);
-  cpu_state->F_ = random(255);
-  cpu_state->IX = random(255);
-  cpu_state->IY = random(255);
-  cpu_state->I = 0;
+  cpu_state->pc.w = 0;
+  cpu_state->sp.w = random(65535);
+  cpu_state->af.w = random(65535);
+  cpu_state->bc.w = random(65535);
+  cpu_state->de.w = random(65535);
+  cpu_state->hl.w = random(65535);
+  cpu_state->af_.w = random(65535);
+  cpu_state->bc_.w = random(65535);
+  cpu_state->de_.w = random(65535);
+  cpu_state->hl_.w = random(65535);
+  cpu_state->ix.w = random(65535);
+  cpu_state->iy.w = random(65535);
+  cpu_state->i = 0;
 }
 
 #define FAST_BLOCK
@@ -146,57 +174,76 @@ static void init_cpu(struct cpu_state *cpu_state)
 
 void cpu_z80(struct cpu_state *cpu_state)
 {
-  BYTE A, B, C, D, E, H, L, F, IFF;
-  BYTE A_, B_, C_, D_, E_, H_, L_, F_, I, R, R_;
-  WORD IX, IY;
-  WORD PC8, SP8;
+  struct cpu_state cpu_regs;
   BYTE t, res, cout, P, op, n, curr_ir;
-  WORD W;
-  WORD IR;
 #ifdef FAST_BLOCK
   WORD s, d;
-  long tl;		/* loops can run for 65535 * 21 + 16 cycles */
+  long tl;			/* loops can run for 65535 * 21 + 16 cycles */
 #endif
 
-#define IR_HL 0		/* values for curr_ir */
-#define IR_IX 1
-#define IR_IY 2
+  struct cpu_reg w;		/* working register */
+  struct cpu_reg ir;		/* current index register (HL, IX, IY) */
 
-  A = cpu_state->A;
-  B = cpu_state->B;
-  C = cpu_state->C;
-  D = cpu_state->D;
-  E = cpu_state->E;
-  H = cpu_state->H;
-  L = cpu_state->L;
-  F = cpu_state->F;
-  IFF = cpu_state->IFF;
-  A_ = cpu_state->A_;
-  B_ = cpu_state->B_;
-  C_ = cpu_state->C_;
-  D_ = cpu_state->D_;
-  E_ = cpu_state->E_;
-  H_ = cpu_state->H_;
-  L_ = cpu_state->L_;
-  F_ = cpu_state->F_;
-  I = cpu_state->I;
-  R = cpu_state->R;
-  R_ = cpu_state->R_;
-  IX = cpu_state->IX;
-  IY = cpu_state->IY;
-  PC8 = cpu_state->PC8;
-  SP8 = cpu_state->SP8;
+#pragma push_macro("F")
+#undef F
+#pragma push_macro("SP")
+#undef SP
+#pragma push_macro("PC")
+#undef PC
+
+#define AF	cpu_regs.af.w
+#define A	cpu_regs.af.h
+#define F	cpu_regs.af.l
+#define BC	cpu_regs.bc.w
+#define B	cpu_regs.bc.h
+#define C	cpu_regs.bc.l
+#define DE	cpu_regs.de.w
+#define D	cpu_regs.de.h
+#define E	cpu_regs.de.l
+#define HL	cpu_regs.hl.w
+#define H	cpu_regs.hl.h
+#define L	cpu_regs.hl.l
+#define SP	cpu_regs.sp.w
+#define SPH	cpu_regs.sp.h
+#define SPL	cpu_regs.sp.l
+#define PC	cpu_regs.pc.w
+#define PCH	cpu_regs.pc.h
+#define PCL	cpu_regs.pc.l
+#define AF_	cpu_regs.af_.w
+#define BC_	cpu_regs.bc_.w
+#define DE_	cpu_regs.de_.w
+#define HL_	cpu_regs.hl_.w
+#define IX	cpu_regs.ix.w
+#define IY	cpu_regs.iy.w
+#define I	cpu_regs.i
+#define R	cpu_regs.r
+#define R_	cpu_regs.r_
+#define IFF	cpu_regs.iff
+
+#define W	w.w
+#define WH	w.h
+#define WL	w.l
+
+#define IR	ir.w
+#define IRH	ir.h
+#define IRL	ir.l
+
+#define IR_HL	0		/* values for curr_ir */
+#define IR_IX	1
+#define IR_IY	2
+
+  cpu_regs = *cpu_state;
 
   do {
     t = 0;
     curr_ir = IR_HL;
-    IR = (H << 8) | L;
+    IR = HL;
 
 next_opcode:
 
     t += 4;
 
-    switch (memrdr(PC8++)) {	/* execute next opcode */
+    switch (memrdr(PC++)) {	/* execute next opcode */
 
       case 0x00:		/* NOP */
       case 0x40:		/* LD B,B */
@@ -209,20 +256,18 @@ next_opcode:
         break;
 
       case 0x01:		/* LD BC,nn */
-        C = memrdr(PC8++);
-        B = memrdr(PC8++);
+        C = memrdr(PC++);
+        B = memrdr(PC++);
         t += 6;
         break;
 
       case 0x02:		/* LD (BC),A */
-        memwrt((B << 8) | C, A);
+        memwrt(BC, A);
         t += 3;
         break;
 
       case 0x03:		/* INC BC */
-        W = ((B << 8) | C) + 1;
-        B = W >> 8;
-        C = W & 0xff;
+        BC++;
         t += 2;
         break;
 
@@ -232,9 +277,9 @@ next_opcode:
 finish_inc:
         cout = (P & 1) | ((P | 1) & ~res);
         F = ((F & C_FLAG) |
-	     ((((cout + 64) >> 7) & 1) << P_SHIFT) |
-	     (((cout >> 3) & 1) << H_SHIFT) |
-	     (szp_flags[res] & ~P_FLAG));
+             ((((cout + 64) >> 7) & 1) << P_SHIFT) |
+             (((cout >> 3) & 1) << H_SHIFT) |
+             (szp_flags[res] & ~P_FLAG));
         /* N_FLAG cleared, C_FLAG unchanged */
         break;
 
@@ -244,15 +289,15 @@ finish_inc:
 finish_dec:
         cout = (~P & 1) | ((~P | 1) & res);
         F = ((F & C_FLAG) |
-	     ((((cout + 64) >> 7) & 1) << P_SHIFT) |
-	     (((cout >> 3) & 1) << H_SHIFT) |
-	     N_FLAG |
-	     (szp_flags[res] & ~P_FLAG));
+             ((((cout + 64) >> 7) & 1) << P_SHIFT) |
+             (((cout >> 3) & 1) << H_SHIFT) |
+             N_FLAG |
+             (szp_flags[res] & ~P_FLAG));
         /* C_FLAG unchanged */
         break;
 
       case 0x06:		/* LD B,n */
-        B = memrdr(PC8++);
+        B = memrdr(PC++);
         t += 3;
         break;
 
@@ -264,35 +309,30 @@ finish_dec:
         break;
 
       case 0x08:		/* EX AF,AF' */
-        P = A;
-        A = A_;
-        A_ = P;
-        P = F;
-        F = F_;
-        F_ = P;
+        W = AF;
+        AF = AF_;
+        AF_ = W;
         break;
 
       case 0x09:		/* ADD ir,BC */
-        W = IR + ((B << 8) | C);
-        cout = ((IR >> 8) & B) | (((IR >> 8) | B) & ~(W >> 8));
-finish_addhl:
+        W = IR + BC;
+        cout = (IRH & B) | ((IRH | B) & ~WH);
+finish_addir:
         F = ((F & ~(H_FLAG | N_FLAG | C_FLAG)) |
-	     (((cout >> 3) & 1) << H_SHIFT) |
-	     (((cout >> 7) & 1) << C_SHIFT));
+             (((cout >> 3) & 1) << H_SHIFT) |
+             (((cout >> 7) & 1) << C_SHIFT));
         /* S_FLAG, Z_FLAG, and P_FLAG unchanged */
         IR = W;
         t += 7;
         break;
 
       case 0x0a:		/* LD A,(BC) */
-        A = memrdr((B << 8) | C);
+        A = memrdr(BC);
         t += 3;
         break;
 
       case 0x0b:		/* DEC BC */
-        W = ((B << 8) | C) - 1;
-        B = W >> 8;
-        C = W & 0xff;
+        BC--;
         t += 2;
         break;
 
@@ -307,7 +347,7 @@ finish_addhl:
         goto finish_dec;
 
       case 0x0e:		/* LD C,n */
-        C = memrdr(PC8++);
+        C = memrdr(PC++);
         t += 3;
         break;
 
@@ -319,29 +359,27 @@ finish_addhl:
         break;
 
       case 0x10:		/* DJNZ n */
-        P = memrdr(PC8++);
+        P = memrdr(PC++);
         t++;
         if (--B) {
-          PC8 += (signed char) P;
+          PC += (signed char) P;
           t += 8;
         }
         break;
 
       case 0x11:		/* LD DE,nn */
-        E = memrdr(PC8++);
-        D = memrdr(PC8++);
+        E = memrdr(PC++);
+        D = memrdr(PC++);
         t += 6;
         break;
 
       case 0x12:		/* LD (DE),A */
-        memwrt((D << 8) | E, A);
+        memwrt(DE, A);
         t += 3;
         break;
 
       case 0x13:		/* INC DE */
-        W = ((D << 8) | E) + 1;
-        D = W >> 8;
-        E = W & 0xff;
+        DE++;
         t += 2;
         break;
 
@@ -356,38 +394,36 @@ finish_addhl:
         goto finish_dec;
 
       case 0x16:		/* LD D,n */
-        D = memrdr(PC8++);
+        D = memrdr(PC++);
         t += 3;
         break;
 
       case 0x17:		/* RLA */
         res = (F >> C_SHIFT) & 1;
         F = ((F & ~(H_FLAG | N_FLAG | C_FLAG)) |
-	     ((((A & 0x80) >> 7) & 1) << C_SHIFT));
+             ((((A & 0x80) >> 7) & 1) << C_SHIFT));
         /* S_FLAG, Z_FLAG, and P_FLAG unchanged */
         A = (A << 1) | res;
         break;
 
       case 0x18:		/* JR n */
-        P = memrdr(PC8++);
-        PC8 += (signed char) P;
+        P = memrdr(PC++);
+        PC += (signed char) P;
         t += 8;
         break;
 
       case 0x19:		/* ADD ir,DE */
-        W = IR + ((D << 8) | E);
-        cout = ((IR >> 8) & D) | (((IR >> 8) | D) & ~(W >> 8));
-        goto finish_addhl;
+        W = IR + DE;
+        cout = (IRH & D) | ((IRH | D) & ~WH);
+        goto finish_addir;
 
       case 0x1a:		/* LD A,(DE) */
-        A = memrdr((D << 8) | E);
+        A = memrdr(DE);
         t += 3;
         break;
 
       case 0x1b:		/* DEC DE */
-        W = ((D << 8) | E) - 1;
-        D = W >> 8;
-        E = W & 0xff;
+        DE--;
         t += 2;
         break;
 
@@ -402,7 +438,7 @@ finish_addhl:
         goto finish_dec;
 
       case 0x1e:		/* LD E,n */
-        E = memrdr(PC8++);
+        E = memrdr(PC++);
         t += 3;
         break;
 
@@ -416,25 +452,25 @@ finish_addhl:
       case 0x20:		/* JR NZ,n */
         res = !(F & Z_FLAG);
 finish_jrc:
-        P = memrdr(PC8++);
+        P = memrdr(PC++);
         t += 3;
         if (res) {
-          PC8 += (signed char) P;
+          PC += (signed char) P;
           t += 5;
         }
         break;
 
       case 0x21:		/* LD ir,nn */
-        IR = memrdr(PC8++);
-        IR |= memrdr(PC8++) << 8;
+        IRL = memrdr(PC++);
+        IRH = memrdr(PC++);
         t += 6;
         break;
 
       case 0x22:		/* LD (nn),ir */
-        W = memrdr(PC8++);
-        W |= memrdr(PC8++) << 8;
-        memwrt(W, IR & 0xff);
-        memwrt(W + 1, IR >> 8);
+        WL = memrdr(PC++);
+        WH = memrdr(PC++);
+        memwrt(W, IRL);
+        memwrt(W + 1, IRH);
         t += 12;
         break;
 
@@ -444,19 +480,17 @@ finish_jrc:
         break;
 
       case 0x24:		/* INC irh */
-        P = IR >> 8;
-        res = P + 1;
-        IR = (IR & 0xff) | (res << 8);
+        P = IRH;
+        res = ++IRH;
         goto finish_inc;
 
       case 0x25:		/* DEC irh */
-        P = IR >> 8;
-        res = P - 1;
-        IR = (IR & 0xff) | (res << 8);
+        P = IRH;
+        res = --IRH;
         goto finish_dec;
 
       case 0x26:		/* LD irh,n */
-        IR = (IR & 0xff) | (memrdr(PC8++) << 8);
+        IRH = memrdr(PC++);
         t += 3;
         break;
 
@@ -476,8 +510,8 @@ finish_jrc:
           cout = (A & P) | ((A | P) & ~res);
         }
         F = ((F & (N_FLAG | C_FLAG)) |
-	     (((cout >> 3) & 1) << H_SHIFT) |
-	     szp_flags[res]);
+             (((cout >> 3) & 1) << H_SHIFT) |
+             szp_flags[res]);
         /* N_FLAG unchanged */
         A = res;
         break;
@@ -488,14 +522,14 @@ finish_jrc:
 
       case 0x29:		/* ADD ir,ir */
         W = IR << 1;
-        cout = (IR >> 8) | ((IR >> 8) & ~(W >> 8));
-        goto finish_addhl;
+        cout = IRH | (IRH & ~WH);
+        goto finish_addir;
 
       case 0x2a:		/* LD ir,(nn) */
-        W = memrdr(PC8++);
-        W |= memrdr(PC8++) << 8;
-        IR = memrdr(W);
-        IR |= memrdr(W + 1) << 8;
+        WL = memrdr(PC++);
+        WH = memrdr(PC++);
+        IRL = memrdr(W);
+        IRH = memrdr(W + 1);
         t += 12;
         break;
 
@@ -505,19 +539,17 @@ finish_jrc:
         break;
 
       case 0x2c:		/* INC irl */
-        P = IR & 0xff;
-        res = P + 1;
-        IR = (IR & ~0xff) | res;
+        P = IRL;
+        res = ++IRL;
         goto finish_inc;
 
       case 0x2d:		/* DEC irl */
-        P = IR & 0xff;
-        res = P - 1;
-        IR = (IR & ~0xff) | res;
+        P = IRL;
+        res = --IRL;
         goto finish_dec;
 
       case 0x2e:		/* LD irl,n */
-        IR = (IR & ~0xff) | memrdr(PC8++);
+        IRL = memrdr(PC++);
         t += 3;
         break;
 
@@ -532,27 +564,27 @@ finish_jrc:
         goto finish_jrc;
 
       case 0x31:		/* LD SP,nn */
-        SP8 = memrdr(PC8++);
-        SP8 |= memrdr(PC8++) << 8;
+        SPL = memrdr(PC++);
+        SPH = memrdr(PC++);
         t += 6;
         break;
 
       case 0x32:		/* LD (nn),A */
-        W = memrdr(PC8++);
-        W |= memrdr(PC8++) << 8;
+        WL = memrdr(PC++);
+        WH = memrdr(PC++);
         memwrt(W, A);
         t += 9;
         break;
 
       case 0x33:		/* INC SP */
-        SP8++;
+        SP++;
         t += 2;
         break;
 
       case 0x34:		/* INC (ir) */
         W = IR;
         if (curr_ir != IR_HL) {
-          W += (signed char) memrdr(PC8++);
+          W += (signed char) memrdr(PC++);
           t += 8;
         }
         P = memrdr(W);
@@ -564,7 +596,7 @@ finish_jrc:
       case 0x35:		/* DEC (ir) */
         W = IR;
         if (curr_ir != IR_HL) {
-          W += (signed char) memrdr(PC8++);
+          W += (signed char) memrdr(PC++);
           t += 8;
         }
         P = memrdr(W);
@@ -576,10 +608,10 @@ finish_jrc:
       case 0x36:		/* LD (ir),n */
         W = IR;
         if (curr_ir != IR_HL) {
-          W += (signed char) memrdr(PC8++);
+          W += (signed char) memrdr(PC++);
           t += 5;
         }
-        memwrt(W, memrdr(PC8++));
+        memwrt(W, memrdr(PC++));
         t += 6;
         break;
 
@@ -594,20 +626,19 @@ finish_jrc:
         goto finish_jrc;
 
       case 0x39:		/* ADD ir,SP */
-        W = IR + SP8;
-        cout = (((IR >> 8) & (SP8 >> 8)) |
-		(((IR >> 8) | (SP8 >> 8)) & ~(W >> 8)));
-        goto finish_addhl;
+        W = IR + SP;
+        cout = (IRH & SPH) | ((IRH | SPH) & ~WH);
+        goto finish_addir;
 
       case 0x3a:		/* LD A,(nn) */
-        W = memrdr(PC8++);
-        W |= memrdr(PC8++) << 8;
+        WL = memrdr(PC++);
+        WH = memrdr(PC++);
         A = memrdr(W);
         t += 9;
         break;
 
       case 0x3b:		/* DEC SP */
-        SP8--;
+        SP--;
         t += 2;
         break;
 
@@ -622,7 +653,7 @@ finish_jrc:
         goto finish_dec;
 
       case 0x3e:		/* LD A,n */
-        A = memrdr(PC8++);
+        A = memrdr(PC++);
         t += 3;
         break;
 
@@ -651,17 +682,17 @@ finish_jrc:
         break;
 
       case 0x44:		/* LD B,irh */
-        B = IR >> 8;
+        B = IRH;
         break;
 
       case 0x45:		/* LD B,irl */
-        B = IR & 0xff;
+        B = IRL;
         break;
 
       case 0x46:		/* LD B,(ir) */
         W = IR;
         if (curr_ir != IR_HL) {
-          W += (signed char) memrdr(PC8++);
+          W += (signed char) memrdr(PC++);
           t += 8;
         }
         B = memrdr(W);
@@ -685,17 +716,17 @@ finish_jrc:
         break;
 
       case 0x4c:		/* LD C,irh */
-        C = IR >> 8;
+        C = IRH;
         break;
 
       case 0x4d:		/* LD C,irl */
-        C = IR & 0xff;
+        C = IRL;
         break;
 
       case 0x4e:		/* LD C,(ir) */
         W = IR;
         if (curr_ir != IR_HL) {
-          W += (signed char) memrdr(PC8++);
+          W += (signed char) memrdr(PC++);
           t += 8;
         }
         C = memrdr(W);
@@ -719,17 +750,17 @@ finish_jrc:
         break;
 
       case 0x54:		/* LD D,irh */
-        D = IR >> 8;
+        D = IRH;
         break;
 
       case 0x55:		/* LD D,irl */
-        D = IR & 0xff;
+        D = IRL;
         break;
 
       case 0x56:		/* LD D,(ir) */
         W = IR;
         if (curr_ir != IR_HL) {
-          W += (signed char) memrdr(PC8++);
+          W += (signed char) memrdr(PC++);
           t += 8;
         }
         D = memrdr(W);
@@ -753,17 +784,17 @@ finish_jrc:
         break;
 
       case 0x5c:		/* LD E,irh */
-        E = IR >> 8;
+        E = IRH;
         break;
 
       case 0x5d:		/* LD E,irl */
-        E = IR & 0xff;
+        E = IRL;
         break;
 
       case 0x5e:		/* LD E,(ir) */
         W = IR;
         if (curr_ir != IR_HL) {
-          W += (signed char) memrdr(PC8++);
+          W += (signed char) memrdr(PC++);
           t += 8;
         }
         E = memrdr(W);
@@ -775,79 +806,79 @@ finish_jrc:
         break;
 
       case 0x60:		/* LD irh,B */
-        IR = (IR & 0xff) | (B << 8);
+        IRH = B;
         break;
 
       case 0x61:		/* LD irh,C */
-        IR = (IR & 0xff) | (C << 8);
+        IRH = C;
         break;
 
       case 0x62:		/* LD irh,D */
-        IR = (IR & 0xff) | (D << 8);
+        IRH = D;
         break;
 
       case 0x63:		/* LD irh,E */
-        IR = (IR & 0xff) | (E << 8);
+        IRH = E;
         break;
 
       case 0x65:		/* LD irh,irl */
-        IR = (IR & 0xff) | ((IR & 0xff) << 8);
+        IRH = IRL;
         break;
 
       case 0x66:		/* LD H,(ir) */
         W = IR;
         if (curr_ir != IR_HL) {
-          W += (signed char) memrdr(PC8++);
+          W += (signed char) memrdr(PC++);
           t += 8;
           H = memrdr(W);
         } else
-          IR = (IR & 0xff) | (memrdr(W) << 8);
+          IRH = memrdr(W);
         t += 3;
         break;
 
       case 0x67:		/* LD irh,A */
-        IR = (IR & 0xff) | (A << 8);
+        IRH = A;
         break;
 
       case 0x68:		/* LD irl,B */
-        IR = (IR & ~0xff) | B;
+        IRL = B;
         break;
 
       case 0x69:		/* LD irl,C */
-        IR = (IR & ~0xff) | C;
+        IRL = C;
         break;
 
       case 0x6a:		/* LD irl,D */
-        IR = (IR & ~0xff) | D;
+        IRL = D;
         break;
 
       case 0x6b:		/* LD irl,E */
-        IR = (IR & ~0xff) | E;
+        IRL = E;
         break;
 
       case 0x6c:		/* LD irl,irh */
-        IR = (IR & ~0xff) | (IR >> 8);
+        IRL = IRH;
         break;
 
       case 0x6e:		/* LD L,(ir) */
         W = IR;
         if (curr_ir != IR_HL) {
-          W += (signed char) memrdr(PC8++);
+          W += (signed char) memrdr(PC++);
           t += 8;
           L = memrdr(W);
         } else
-          IR = (IR & ~0xff) | memrdr(W);
+          IRL = memrdr(W);
         t += 3;
         break;
 
       case 0x6f:		/* LD irl,A */
-        IR = (IR & ~0xff) | A;
+        IRL = A;
         break;
 
       case 0x70:		/* LD (ir),B */
         W = IR;
         if (curr_ir != IR_HL) {
-          W += (signed char) memrdr(PC8++);
+          W += (signed char) memrdr(PC++);
           t += 8;
         }
         memwrt(W, B);
@@ -857,7 +888,7 @@ finish_jrc:
       case 0x71:		/* LD (ir),C */
         W = IR;
         if (curr_ir != IR_HL) {
-          W += (signed char) memrdr(PC8++);
+          W += (signed char) memrdr(PC++);
           t += 8;
         }
         memwrt(W, C);
@@ -867,7 +898,7 @@ finish_jrc:
       case 0x72:		/* LD (ir),D */
         W = IR;
         if (curr_ir != IR_HL) {
-          W += (signed char) memrdr(PC8++);
+          W += (signed char) memrdr(PC++);
           t += 8;
         }
         memwrt(W, D);
@@ -877,7 +908,7 @@ finish_jrc:
       case 0x73:		/* LD (ir),E */
         W = IR;
         if (curr_ir != IR_HL) {
-          W += (signed char) memrdr(PC8++);
+          W += (signed char) memrdr(PC++);
           t += 8;
         }
         memwrt(W, E);
@@ -887,22 +918,22 @@ finish_jrc:
       case 0x74:		/* LD (ir),H */
         W = IR;
         if (curr_ir != IR_HL) {
-          W += (signed char) memrdr(PC8++);
+          W += (signed char) memrdr(PC++);
           t += 8;
           memwrt(W, H);
         } else
-          memwrt(W, IR >> 8);
+          memwrt(W, IRH);
         t += 3;
         break;
 
       case 0x75:		/* LD (ir),L */
         W = IR;
         if (curr_ir != IR_HL) {
-          W += (signed char) memrdr(PC8++);
+          W += (signed char) memrdr(PC++);
           t += 8;
           memwrt(W, L);
         } else
-          memwrt(W, IR & 0xff);
+          memwrt(W, IRL);
         t += 3;
         break;
 
@@ -914,7 +945,7 @@ finish_jrc:
       case 0x77:		/* LD (ir),A */
         W = IR;
         if (curr_ir != IR_HL) {
-          W += (signed char) memrdr(PC8++);
+          W += (signed char) memrdr(PC++);
           t += 8;
         }
         memwrt(W, A);
@@ -938,17 +969,17 @@ finish_jrc:
         break;
 
       case 0x7c:		/* LD A,irh */
-        A = IR >> 8;
+        A = IRH;
         break;
 
       case 0x7d:		/* LD A,irl */
-        A = IR & 0xff;
+        A = IRL;
         break;
 
       case 0x7e:		/* LD A,(ir) */
         W = IR;
         if (curr_ir != IR_HL) {
-          W += (signed char) memrdr(PC8++);
+          W += (signed char) memrdr(PC++);
           t += 8;
         }
         A = memrdr(W);
@@ -957,138 +988,152 @@ finish_jrc:
 
       case 0x80:		/* ADD A,B */
         P = B;
+        res = 0;
 finish_add:
-        res = A + P;
+        res = A + P + res;
         cout = (A & P) | ((A | P) & ~res);
         F = ((((cout >> 7) & 1) << C_SHIFT) |
-	     ((((cout + 64) >> 7) & 1) << P_SHIFT) |
-	     (((cout >> 3) & 1) << H_SHIFT) |
-	     (szp_flags[res] & ~P_FLAG));
+             ((((cout + 64) >> 7) & 1) << P_SHIFT) |
+             (((cout >> 3) & 1) << H_SHIFT) |
+             (szp_flags[res] & ~P_FLAG));
         /* N_FLAG cleared */
         A = res;
         break;
 
       case 0x81:		/* ADD A,C */
         P = C;
+        res = 0;
         goto finish_add;
 
       case 0x82:		/* ADD A,D */
         P = D;
+        res = 0;
         goto finish_add;
 
       case 0x83:		/* ADD A,E */
         P = E;
+        res = 0;
         goto finish_add;
 
       case 0x84:		/* ADD A,irh */
-        P = IR >> 8;
+        P = IRH;
+        res = 0;
         goto finish_add;
 
       case 0x85:		/* ADD A,irl */
-        P = IR & 0xff;
+        P = IRL;
+        res = 0;
         goto finish_add;
 
       case 0x86:		/* ADD A,(ir) */
         W = IR;
         if (curr_ir != IR_HL) {
-          W += (signed char) memrdr(PC8++);
+          W += (signed char) memrdr(PC++);
           t += 8;
         }
         P = memrdr(W);
+        res = 0;
         t += 3;
         goto finish_add;
 
       case 0x87:		/* ADD A,A */
         P = A;
+        res = 0;
         goto finish_add;
 
       case 0x88:		/* ADC A,B */
         P = B;
-finish_adc:
-        res = A + P + ((F >> C_SHIFT) & 1);
-        cout = (A & P) | ((A | P) & ~res);
-        F = ((((cout >> 7) & 1) << C_SHIFT) |
-	     ((((cout + 64) >> 7) & 1) << P_SHIFT) |
-	     (((cout >> 3) & 1) << H_SHIFT) |
-	     (szp_flags[res] & ~P_FLAG));
-        /* N_FLAG cleared */
-        A = res;
-        break;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_add;
 
       case 0x89:		/* ADC A,C */
         P = C;
-        goto finish_adc;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_add;
 
       case 0x8a:		/* ADC A,D */
         P = D;
-        goto finish_adc;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_add;
 
       case 0x8b:		/* ADC A,E */
         P = E;
-        goto finish_adc;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_add;
 
       case 0x8c:		/* ADC A,irh */
-        P = IR >> 8;
-        goto finish_adc;
+        P = IRH;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_add;
 
       case 0x8d:		/* ADC A,irl */
-        P = IR & 0xff;
-        goto finish_adc;
+        P = IRL;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_add;
 
       case 0x8e:		/* ADC A,(ir) */
         W = IR;
         if (curr_ir != IR_HL) {
-          W += (signed char) memrdr(PC8++);
+          W += (signed char) memrdr(PC++);
           t += 8;
         }
         P = memrdr(W);
+        res = (F >> C_SHIFT) & 1;
         t += 3;
-        goto finish_adc;
+        goto finish_add;
 
       case 0x8f:		/* ADC A,A */
         P = A;
-        goto finish_adc;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_add;
 
       case 0x90:		/* SUB A,B */
         P = B;
+        res = 0;
 finish_sub:
-        res = A - P;
+        res = A - P - res;
         cout = (~A & P) | ((~A | P) & res);
         F = ((((cout >> 7) & 1) << C_SHIFT) |
-	     ((((cout + 64) >> 7) & 1) << P_SHIFT) |
-	     (((cout >> 3) & 1) << H_SHIFT) |
-	     N_FLAG |
-	     (szp_flags[res] & ~P_FLAG));
+             ((((cout + 64) >> 7) & 1) << P_SHIFT) |
+             (((cout >> 3) & 1) << H_SHIFT) |
+             N_FLAG |
+             (szp_flags[res] & ~P_FLAG));
         A = res;
         break;
 
       case 0x91:		/* SUB A,C */
         P = C;
+        res = 0;
         goto finish_sub;
 
       case 0x92:		/* SUB A,D */
         P = D;
+        res = 0;
         goto finish_sub;
 
       case 0x93:		/* SUB A,E */
         P = E;
+        res = 0;
         goto finish_sub;
 
       case 0x94:		/* SUB A,irh */
-        P = IR >> 8;
+        P = IRH;
+        res = 0;
         goto finish_sub;
 
       case 0x95:		/* SUB A,irl */
-        P = IR & 0xff;
+        P = IRL;
+        res = 0;
         goto finish_sub;
 
       case 0x96:		/* SUB A,(ir) */
         W = IR;
         if (curr_ir != IR_HL) {
-          W += (signed char) memrdr(PC8++);
+          W += (signed char) memrdr(PC++);
           t += 8;
         }
         P = memrdr(W);
+        res = 0;
         t += 3;
         goto finish_sub;
 
@@ -1100,50 +1145,49 @@ finish_sub:
 
       case 0x98:		/* SBC A,B */
         P = B;
-finish_sbc:
-        res = A - P - ((F >> C_SHIFT) & 1);
-        cout = (~A & P) | ((~A | P) & res);
-        F = ((((cout >> 7) & 1) << C_SHIFT) |
-	     ((((cout + 64) >> 7) & 1) << P_SHIFT) |
-	     (((cout >> 3) & 1) << H_SHIFT) |
-	     N_FLAG |
-	     (szp_flags[res] & ~P_FLAG));
-        A = res;
-        break;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_sub;
 
       case 0x99:		/* SBC A,C */
         P = C;
-        goto finish_sbc;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_sub;
 
       case 0x9a:		/* SBC A,D */
         P = D;
-        goto finish_sbc;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_sub;
 
       case 0x9b:		/* SBC A,E */
         P = E;
-        goto finish_sbc;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_sub;
 
       case 0x9c:		/* SBC A,irh */
-        P = IR >> 8;
-        goto finish_sbc;
+        P = IRH;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_sub;
 
       case 0x9d:		/* SBC A,irl */
-        P = IR & 0xff;
-        goto finish_sbc;
+        P = IRL;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_sub;
 
       case 0x9e:		/* SBC A,(ir) */
         W = IR;
         if (curr_ir != IR_HL) {
-          W += (signed char) memrdr(PC8++);
+          W += (signed char) memrdr(PC++);
           t += 8;
         }
         P = memrdr(W);
+        res = (F >> C_SHIFT) & 1;
         t += 3;
-        goto finish_sbc;
+        goto finish_sub;
 
       case 0x9f:		/* SBC A,A */
         P = A;
-        goto finish_sbc;
+        res = (F >> C_SHIFT) & 1;
+        goto finish_sub;
 
       case 0xa0:		/* AND B */
         P = B;
@@ -1167,17 +1211,17 @@ finish_and:
         goto finish_and;
 
       case 0xa4:		/* AND irh */
-        P = IR >> 8;
+        P = IRH;
         goto finish_and;
 
       case 0xa5:		/* AND irl */
-        P = IR & 0xff;
+        P = IRL;
         goto finish_and;
 
       case 0xa6:		/* AND (ir) */
         W = IR;
         if (curr_ir != IR_HL) {
-          W += (signed char) memrdr(PC8++);
+          W += (signed char) memrdr(PC++);
           t += 8;
         }
         P = memrdr(W);
@@ -1210,17 +1254,17 @@ finish_xor:
         goto finish_xor;
 
       case 0xac:		/* XOR irh */
-        P = IR >> 8;
+        P = IRH;
         goto finish_xor;
 
       case 0xad:		/* XOR irl */
-        P = IR & 0xff;
+        P = IRL;
         goto finish_xor;
 
       case 0xae:		/* XOR (ir) */
         W = IR;
         if (curr_ir != IR_HL) {
-          W += (signed char) memrdr(PC8++);
+          W += (signed char) memrdr(PC++);
           t += 8;
         }
         P = memrdr(W);
@@ -1255,17 +1299,17 @@ finish_or:
         goto finish_or;
 
       case 0xb4:		/* OR irh */
-        P = IR >> 8;
+        P = IRH;
         goto finish_or;
 
       case 0xb5:		/* OR irl */
-        P = IR & 0xff;
+        P = IRL;
         goto finish_or;
 
       case 0xb6:		/* OR (ir) */
         W = IR;
         if (curr_ir != IR_HL) {
-          W += (signed char) memrdr(PC8++);
+          W += (signed char) memrdr(PC++);
           t += 8;
         }
         P = memrdr(W);
@@ -1283,10 +1327,10 @@ finish_cp:
         res = A - P;
         cout = (~A & P) | ((~A | P) & res);
         F = ((((cout >> 7) & 1) << C_SHIFT) |
-	     ((((cout + 64) >> 7) & 1) << P_SHIFT) |
-	     (((cout >> 3) & 1) << H_SHIFT) |
-	     N_FLAG |
-	     (szp_flags[res] & ~P_FLAG));
+             ((((cout + 64) >> 7) & 1) << P_SHIFT) |
+             (((cout >> 3) & 1) << H_SHIFT) |
+             N_FLAG |
+             (szp_flags[res] & ~P_FLAG));
         break;
 
       case 0xb9:		/* CP C */
@@ -1302,17 +1346,17 @@ finish_cp:
         goto finish_cp;
 
       case 0xbc:		/* CP irh */
-        P = IR >> 8;
+        P = IRH;
         goto finish_cp;
 
       case 0xbd:		/* CP irl */
-        P = IR & 0xff;
+        P = IRL;
         goto finish_cp;
 
       case 0xbe:		/* CP (ir) */
         W = IR;
         if (curr_ir != IR_HL) {
-          W += (signed char) memrdr(PC8++);
+          W += (signed char) memrdr(PC++);
           t += 8;
         }
         P = memrdr(W);
@@ -1333,46 +1377,47 @@ finish_retc:
         break;
 
       case 0xc1:		/* POP BC */
-        C = memrdr(SP8++);
-        B = memrdr(SP8++);
+        C = memrdr(SP++);
+        B = memrdr(SP++);
         t += 6;
         break;
 
       case 0xc2:		/* JP NZ,nn */
         res = !(F & Z_FLAG);
 finish_jpc:
-        W = memrdr(PC8++);
-        W |= memrdr(PC8++) << 8;
+        WL = memrdr(PC++);
+        WH = memrdr(PC++);
         t += 6;
         if (res)
-          PC8 = W;
+          PC = W;
         break;
 
       case 0xc3:		/* JP nn */
-        W = memrdr(PC8++);
-        W |= memrdr(PC8) << 8;
+        WL = memrdr(PC++);
+        WH = memrdr(PC);
         t += 6;
-        PC8 = W;
+        PC = W;
         break;
 
       case 0xc4:		/* CALL NZ,nn */
         res = !(F & Z_FLAG);
 finish_callc:
-        W = memrdr(PC8++);
-        W |= memrdr(PC8++) << 8;
+        WL = memrdr(PC++);
+        WH = memrdr(PC++);
         t += 6;
         if (res)
           goto finish_call;
         break;
 
       case 0xc5:		/* PUSH BC */
-        memwrt(--SP8, B);
-        memwrt(--SP8, C);
+        memwrt(--SP, B);
+        memwrt(--SP, C);
         t += 7;
         break;
 
       case 0xc6:		/* ADD A,n */
-        P = memrdr(PC8++);
+        P = memrdr(PC++);
+        res = 0;
         t += 3;
         goto finish_add;
 
@@ -1386,10 +1431,10 @@ finish_callc:
 
       case 0xc9:		/* RET */
 finish_ret:
-        W = memrdr(SP8++);
-        W |= memrdr(SP8++) << 8;
+        WL = memrdr(SP++);
+        WH = memrdr(SP++);
         t += 6;
-        PC8 = W;
+        PC = W;
         break;
 
       case 0xca:		/* JP Z,nn */
@@ -1399,17 +1444,17 @@ finish_ret:
       case 0xcb:		/* 0xcb prefix */
         W = IR;
         if (curr_ir != IR_HL) {
-          W += (signed char) memrdr(PC8++);
+          W += (signed char) memrdr(PC++);
           t += 8;
         } else {
           R++;			/* increment refresh register */
-	}
+        }
 
         t += 4;
 
         res = 0;		/* silence compiler */
 
-        op = memrdr(PC8++);
+        op = memrdr(PC++);
         n = (op >> 3) & 7;
         if (curr_ir != IR_HL)
           P = memrdr(W);
@@ -1428,10 +1473,10 @@ finish_ret:
               P = E;
               break;
             case 4:
-              P = IR >> 8;
+              P = IRH;
               break;
             case 5:
-              P = IR & 0xff;
+              P = IRL;
               break;
             case 6:
               P = memrdr(W);
@@ -1459,7 +1504,7 @@ finish_ret:
                 break;
               case 3:		/* RR */
                 res = ((P >> 1) |
-		       (((F & C_FLAG) >> C_SHIFT) << 7));
+                       (((F & C_FLAG) >> C_SHIFT) << 7));
                 F = (P & 1) << C_SHIFT;
                 break;
               case 4:		/* SLA */
@@ -1513,13 +1558,13 @@ finish_ret:
             if (curr_ir != IR_HL)
               H = res;
             else
-              IR = (IR & 0xff) | (res << 8);
+              IRH = res;
             break;
           case 5:
             if (curr_ir != IR_HL)
               L = res;
             else
-              IR = (IR & ~0xff) | res;
+              IRL = res;
             break;
           case 6:
             if (curr_ir == IR_HL)
@@ -1538,20 +1583,21 @@ end_cb:
         goto finish_callc;
 
       case 0xcd:		/* CALL nn */
-        W = memrdr(PC8++);
-        W |= memrdr(PC8++) << 8;
+        WL = memrdr(PC++);
+        WH = memrdr(PC++);
         t += 6;
 finish_call:
-        memwrt(--SP8, PC8 >> 8);
-        memwrt(--SP8, PC8 & 0xff);
+        memwrt(--SP, PCH);
+        memwrt(--SP, PCL);
         t += 7;
-        PC8 = W;
+        PC = W;
         break;
 
       case 0xce:		/* ADC A,n */
-        P = memrdr(PC8++);
+        P = memrdr(PC++);
+        res = (F >> C_SHIFT) & 1;
         t += 3;
-        goto finish_adc;
+        goto finish_add;
 
       case 0xcf:		/* RST 08 */
         W = 0x08;
@@ -1562,8 +1608,8 @@ finish_call:
         goto finish_retc;
 
       case 0xd1:		/* POP DE */
-        E = memrdr(SP8++);
-        D = memrdr(SP8++);
+        E = memrdr(SP++);
+        D = memrdr(SP++);
         t += 6;
         break;
 
@@ -1572,7 +1618,7 @@ finish_call:
         goto finish_jpc;
 
       case 0xd3:		/* OUT (n),A */
-        P = memrdr(PC8++);
+        P = memrdr(PC++);
         io_out(P, A, A);
         t += 7;
         break;
@@ -1582,13 +1628,14 @@ finish_call:
         goto finish_callc;
 
       case 0xd5:		/* PUSH DE */
-        memwrt(--SP8, D);
-        memwrt(--SP8, E);
+        memwrt(--SP, D);
+        memwrt(--SP, E);
         t += 7;
         break;
 
       case 0xd6:		/* SUB A,n */
-        P = memrdr(PC8++);
+        P = memrdr(PC++);
+        res = 0;
         t += 3;
         goto finish_sub;
 
@@ -1601,26 +1648,17 @@ finish_call:
         goto finish_retc;
 
       case 0xd9:		/* EXX */
-        P = B;
-        B = B_;
-        B_ = P;
-        P = C;
-        C = C_;
-        C_ = P;
-        P = D;
-        D = D_;
-        D_ = P;
-        P = E;
-        E = E_;
-        E_ = P;
-        P = H;
-        H = H_;
-        H_ = P;
-        P = L;
-        L = L_;
-        L_ = P;
+        W = BC;
+        BC = BC_;
+        BC_ = W;
+        W = DE;
+        DE = DE_;
+        DE_ = W;
+        W = HL;
+        HL = HL_;
+        HL_ = W;
         curr_ir = IR_HL;
-        IR = (H << 8) | L;
+        IR = HL;
         break;
 
       case 0xda:		/* JP C,nn */
@@ -1628,7 +1666,7 @@ finish_call:
         goto finish_jpc;
 
       case 0xdb:		/* IN A,(n) */
-        P = memrdr(PC8++);
+        P = memrdr(PC++);
         A = io_in(P, A);
         t += 7;
         break;
@@ -1645,9 +1683,10 @@ finish_call:
         goto next_opcode;
 
       case 0xde:		/* SBC A,n */
-        P = memrdr(PC8++);
+        P = memrdr(PC++);
+        res = (F >> C_SHIFT) & 1;
         t += 3;
-        goto finish_sbc;
+        goto finish_sub;
 
       case 0xdf:		/* RST 18 */
         W = 0x18;
@@ -1658,8 +1697,8 @@ finish_call:
         goto finish_retc;
 
       case 0xe1:		/* POP ir */
-        IR = memrdr(SP8++);
-        IR |= memrdr(SP8++) << 8;
+        IRL = memrdr(SP++);
+        IRH = memrdr(SP++);
         t += 6;
         break;
 
@@ -1668,10 +1707,10 @@ finish_call:
         goto finish_jpc;
 
       case 0xe3:		/* EX (SP),ir */
-        W = memrdr(SP8);
-        W |= memrdr(SP8 + 1) << 8;
-        memwrt(SP8, IR & 0xff);
-        memwrt(SP8 + 1, IR >> 8);
+        WL = memrdr(SP);
+        WH = memrdr(SP + 1);
+        memwrt(SP, IRL);
+        memwrt(SP + 1, IRH);
         IR = W;
         t += 15;
         break;
@@ -1681,13 +1720,13 @@ finish_call:
         goto finish_callc;
 
       case 0xe5:		/* PUSH ir */
-        memwrt(--SP8, IR >> 8);
-        memwrt(--SP8, IR & 0xff);
+        memwrt(--SP, IRH);
+        memwrt(--SP, IRL);
         t += 7;
         break;
 
       case 0xe6:		/* AND n */
-        P = memrdr(PC8++);
+        P = memrdr(PC++);
         t += 3;
         goto finish_and;
 
@@ -1700,7 +1739,7 @@ finish_call:
         goto finish_retc;
 
       case 0xe9:		/* JP (ir) */
-        PC8 = IR;
+        PC = IR;
         break;
 
       case 0xea:		/* JP PE,nn */
@@ -1708,14 +1747,11 @@ finish_call:
         goto finish_jpc;
 
       case 0xeb:		/* EX DE,HL */
-        P = D;
-        D = H;
-        H = P;
-        P = E;
-        E = L;
-        L = P;
+        W = DE;
+        DE = HL;
+        HL = W;
         curr_ir = IR_HL;
-        IR = (H << 8) | L;
+        IR = HL;
         break;
 
       case 0xec:		/* CALL PE,nn */
@@ -1727,7 +1763,7 @@ finish_call:
 
         t += 4;
 
-        switch (memrdr(PC8++)) {
+        switch (memrdr(PC++)) {
           case 0x40:		/* IN B,(C) */
             B = io_in(C, B);
             F = (F & C_FLAG) | szp_flags[B];
@@ -1741,24 +1777,22 @@ finish_call:
             break;
 
           case 0x42:		/* SBC HL,BC */
-            W = (((H << 8) | L) - ((B << 8) | C)
-                 - ((F >> C_SHIFT) & 1));
-            cout = (~H & B) | ((~H | B) & (W >> 8));
-finish_sbchl:
-            F = ((((cout >> 7) & 1) << C_SHIFT) |
-		 ((((cout + 64) >> 7) & 1) << P_SHIFT) |
-		 (((cout >> 3) & 1) << H_SHIFT) |
-		 N_FLAG |
-		 ((W == 0) << Z_SHIFT) |
-		 ((((W >> 8) & 0x80) >> 7) << S_SHIFT));
-            H = W >> 8;
-            L = W & 0xff;
+            W = HL - BC - ((F >> C_SHIFT) & 1);
+            cout = (~H & B) | ((~H | B) & WH);
+            F = N_FLAG;
+finish_sachl:
+            F |= ((((cout >> 7) & 1) << C_SHIFT) |
+                  ((((cout + 64) >> 7) & 1) << P_SHIFT) |
+                  (((cout >> 3) & 1) << H_SHIFT) |
+                  ((W == 0) << Z_SHIFT) |
+                  (((WH & 0x80) >> 7) << S_SHIFT));
+            HL = W;
             t += 7;
             break;
 
           case 0x43:		/* LD (nn),BC */
-            W = memrdr(PC8++);
-            W |= memrdr(PC8++) << 8;
+            WL = memrdr(PC++);
+            WH = memrdr(PC++);
             memwrt(W, C);
             memwrt(W + 1, B);
             t += 12;
@@ -1772,24 +1806,18 @@ finish_sbchl:
           case 0x6c:		/* NEG* */
           case 0x74:		/* NEG* */
           case 0x7c:		/* NEG* */
-            res = 0 - A;
-            cout = A | res;
-            F = ((((cout >> 7) & 1) << C_SHIFT) |
-		 ((((cout + 64) >> 7) & 1) << P_SHIFT) |
-		 (((cout >> 3) & 1) << H_SHIFT) |
-		 N_FLAG |
-		 (szp_flags[res] & ~P_FLAG));
-            A = res;
-            break;
+            P = A;
+            res = A = 0;
+            goto finish_sub;
 
           case 0x45:		/* RETN */
           case 0x55:		/* RETN* */
           case 0x65:		/* RETN* */
           case 0x75:		/* RETN* */
-            W = memrdr(SP8++);
-            W |= memrdr(SP8++) << 8;
+            WL = memrdr(SP++);
+            WH = memrdr(SP++);
             t += 6;
-            PC8 = W;
+            PC = W;
             if (IFF & 2)
               IFF |= 1;
             break;
@@ -1819,24 +1847,14 @@ finish_sbchl:
             break;
 
           case 0x4a:		/* ADC HL,BC */
-            W = (((H << 8) | L) + ((B << 8) | C) +
-		 ((F >> C_SHIFT) & 1));
-            cout = (H & B) | ((H | B) & ~(W >> 8));
-finish_adchl:
-            F = ((((cout >> 7) & 1) << C_SHIFT) |
-		 ((((cout + 64) >> 7) & 1) << P_SHIFT) |
-		 (((cout >> 3) & 1) << H_SHIFT) |
-		 ((W == 0) << Z_SHIFT) |
-		 ((((W >> 8) & 0x80) >> 7) << S_SHIFT));
-            /* N_FLAG cleared */
-            H = W >> 8;
-            L = W & 0xff;
-            t += 7;
-            break;
+            W = HL + BC + ((F >> C_SHIFT) & 1);
+            cout = (H & B) | ((H | B) & ~WH);
+            F = 0;
+            goto finish_sachl;
 
           case 0x4b:		/* LD BC,(nn) */
-            W = memrdr(PC8++);
-            W |= memrdr(PC8++) << 8;
+            WL = memrdr(PC++);
+            WH = memrdr(PC++);
             C = memrdr(W);
             B = memrdr(W + 1);
             t += 12;
@@ -1846,10 +1864,10 @@ finish_adchl:
           case 0x5d:		/* RETI* */
           case 0x6d:		/* RETI* */
           case 0x7d:		/* RETI* */
-            W = memrdr(SP8++);
-            W |= memrdr(SP8++) << 8;
+            WL = memrdr(SP++);
+            WH = memrdr(SP++);
             t += 6;
-            PC8 = W;
+            PC = W;
             break;
 
           case 0x4f:		/* LD R,A */
@@ -1870,14 +1888,14 @@ finish_adchl:
             break;
 
           case 0x52:		/* SBC HL,DE */
-            W = (((H << 8) | L) - ((D << 8) | E) -
-		 ((F >> C_SHIFT) & 1));
-            cout = (~H & D) | ((~H | D) & (W >> 8));
-            goto finish_sbchl;
+            W = HL - DE - ((F >> C_SHIFT) & 1);
+            cout = (~H & D) | ((~H | D) & WH);
+            F = N_FLAG;
+            goto finish_sachl;
 
           case 0x53:		/* LD (nn),DE */
-            W = memrdr(PC8++);
-            W |= memrdr(PC8++) << 8;
+            WL = memrdr(PC++);
+            WH = memrdr(PC++);
             memwrt(W, E);
             memwrt(W + 1, D);
             t += 12;
@@ -1890,9 +1908,10 @@ finish_adchl:
 
           case 0x57:		/* LD A,I */
             A = I;
+finish_ldair:
             F = ((F & C_FLAG) |
-		 (((IFF >> 1) & 1) << P_SHIFT) |
-		 (szp_flags[A] & ~P_FLAG));
+                 (((IFF >> 1) & 1) << P_SHIFT) |
+                 (szp_flags[A] & ~P_FLAG));
             /* H_FLAG and N_FLAG cleared, C_FLAG unchanged */
             t++;
             break;
@@ -1910,14 +1929,14 @@ finish_adchl:
             break;
 
           case 0x5a:		/* ADC HL,DE */
-            W = (((H << 8) | L) + ((D << 8) | E) +
-		 ((F >> C_SHIFT) & 1));
-            cout = (H & D) | ((H | D) & ~(W >> 8));
-            goto finish_adchl;
+            W = HL + DE + ((F >> C_SHIFT) & 1);
+            cout = (H & D) | ((H | D) & ~WH);
+            F = 0;
+            goto finish_sachl;
 
           case 0x5b:		/* LD DE,(nn) */
-            W = memrdr(PC8++);
-            W |= memrdr(PC8++) << 8;
+            WL = memrdr(PC++);
+            WH = memrdr(PC++);
             E = memrdr(W);
             D = memrdr(W + 1);
             t += 12;
@@ -1930,12 +1949,7 @@ finish_adchl:
 
           case 0x5f:		/* LD A,R */
             A = (R_ & 0x80) | (R & 0x7f);
-            F = ((F & C_FLAG) |
-		 (((IFF >> 1) & 1) << P_SHIFT) |
-		 (szp_flags[A] & ~P_FLAG));
-            /* H_FLAG and N_FLAG cleared, C_FLAG unchanged */
-            t++;
-            break;
+            goto finish_ldair;
 
           case 0x60:		/* IN H,(C) */
             H = io_in(C, B);
@@ -1951,22 +1965,23 @@ finish_adchl:
 
           case 0x62:		/* SBC HL,HL */
             W = -((F >> C_SHIFT) & 1);
-            cout = W >> 8;
-            goto finish_sbchl;
+            cout = WH;
+            F = N_FLAG;
+            goto finish_sachl;
 
           case 0x63:		/* LD (nn),HL */
-            W = memrdr(PC8++);
-            W |= memrdr(PC8++) << 8;
+            WL = memrdr(PC++);
+            WH = memrdr(PC++);
             memwrt(W, L);
             memwrt(W + 1, H);
             t += 12;
             break;
 
           case 0x67:		/* RRD (HL) */
-            P = memrdr((H << 8) | L);
+            P = memrdr(HL);
             res = A & 0x0f;
             A = (A & 0xf0) | (P & 0x0f);
-            memwrt((H << 8) | L, ((P >> 4) | (res << 4)));
+            memwrt(HL, ((P >> 4) | (res << 4)));
             F = (F & C_FLAG) | szp_flags[A];
             /* H_FLAG and N_FLAG cleared, C_FLAG unchanged */
             t += 10;
@@ -1985,23 +2000,24 @@ finish_adchl:
             break;
 
           case 0x6a:		/* ADC HL,HL */
-            W = (((H << 8) | L) << 1) + ((F >> C_SHIFT) & 1);
-            cout = H | (H & ~(W >> 8));
-            goto finish_adchl;
+            W = (HL << 1) + ((F >> C_SHIFT) & 1);
+            cout = H | (H & ~WH);
+            F = 0;
+            goto finish_sachl;
 
           case 0x6b:		/* LD HL,(nn) */
-            W = memrdr(PC8++);
-            W |= memrdr(PC8++) << 8;
+            WL = memrdr(PC++);
+            WH = memrdr(PC++);
             L = memrdr(W);
             H = memrdr(W + 1);
             t += 12;
             break;
 
           case 0x6f:		/* RLD (HL) */
-            P = memrdr((H << 8) | L);
+            P = memrdr(HL);
             res = A & 0x0f;
             A = (A & 0xf0) | (P >> 4);
-            memwrt((H << 8) | L, (P << 4) | res);
+            memwrt(HL, (P << 4) | res);
             F = (F & C_FLAG) | szp_flags[A];
             /* H_FLAG and N_FLAG cleared, C_FLAG unchanged */
             t += 10;
@@ -2020,16 +2036,16 @@ finish_adchl:
             break;
 
           case 0x72:		/* SBC HL,SP */
-            W = ((H << 8) | L) - SP8 - ((F >> C_SHIFT) & 1);
-            cout = ((~H & (SP8 >> 8)) |
-		    ((~H | (SP8 >> 8)) & (W >> 8)));
-            goto finish_sbchl;
+            W = HL - SP - ((F >> C_SHIFT) & 1);
+            cout = (~H & SPH) | ((~H | SPH) & WH);
+            F = N_FLAG;
+            goto finish_sachl;
 
           case 0x73:		/* LD (nn),SP */
-            W = memrdr(PC8++);
-            W |= memrdr(PC8++) << 8;
-            memwrt(W, SP8 & 0xff);
-            memwrt(W + 1, SP8 >> 8);
+            WL = memrdr(PC++);
+            WH = memrdr(PC++);
+            memwrt(W, SPL);
+            memwrt(W + 1, SPH);
             t += 12;
             break;
 
@@ -2046,121 +2062,88 @@ finish_adchl:
             break;
 
           case 0x7a:		/* ADC HL,SP */
-            W = ((H << 8) | L) + SP8 + ((F >> C_SHIFT) & 1);
-            cout = (H & (SP8 >> 8)) | ((H | (SP8 >> 8)) & ~(W >> 8));
-            goto finish_adchl;
+            W = HL + SP + ((F >> C_SHIFT) & 1);
+            cout = (H & SPH) | ((H | SPH) & ~WH);
+            F = 0;
+            goto finish_sachl;
 
           case 0x7b:		/* LD SP,(nn) */
-            W = memrdr(PC8++);
-            W |= memrdr(PC8++) << 8;
-            SP8 = memrdr(W);
-            SP8 |= memrdr(W + 1) << 8;
+            WL = memrdr(PC++);
+            WH = memrdr(PC++);
+            SPL = memrdr(W);
+            SPH = memrdr(W + 1);
             t += 12;
             break;
 
           case 0xa0:		/* LDI */
-            memwrt((D << 8) | E, memrdr((H << 8) | L));
-            W = ((D << 8) | E) + 1;
-            D = W >> 8;
-            E = W & 0xff;
-            W = ((H << 8) | L) + 1;
-            H = W >> 8;
-            L = W & 0xff;
+            memwrt(DE++, memrdr(HL++));
 finish_ldid:
-            W = ((B << 8) | C) - 1;
-            B = W >> 8;
-            C = W & 0xff;
+            BC--;
             F = ((F & ~(H_FLAG | N_FLAG | P_FLAG)) |
-		 (((B | C) != 0) << P_SHIFT));
+                 ((BC != 0) << P_SHIFT));
             /* S_FLAG, Z_FLAG, and C_FLAG unchanged */
             t += 8;
             break;
 
           case 0xa1:		/* CPI */
-            P = memrdr((H << 8) | L);
-            W = ((H << 8) | L) + 1;
-            H = W >> 8;
-            L = W & 0xff;
+            P = memrdr(HL++);
 finish_cpid:
-            W = ((B << 8) | C) - 1;
-            B = W >> 8;
-            C = W & 0xff;
+            BC--;
             res = A - P;
             cout = (~A & P) | ((~A | P) & res);
             F = ((F & C_FLAG) |
-		 (((cout >> 3) & 1) << H_SHIFT) |
-		 N_FLAG |
-		 (((B | C) != 0) << P_SHIFT) |
-		 (szp_flags[res] & ~P_FLAG));
+                 (((cout >> 3) & 1) << H_SHIFT) |
+                 N_FLAG |
+                 ((BC != 0) << P_SHIFT) |
+                 (szp_flags[res] & ~P_FLAG));
             /* C_FLAG unchanged */
             t += 8;
             break;
 
           case 0xa2:		/* INI */
             res = io_in(C, B--);
-            memwrt((H << 8) | L, res);
-            W = ((H << 8) | L) + 1;
-            H = W >> 8;
-            L = W & 0xff;
+            memwrt(HL++, res);
             W = (C + 1) & 0xff;
 finish_ioid:
             W += res;
-            F = (((W >> 8) << H_SHIFT) | ((W >> 8) << C_SHIFT) |
-		 ((((res & 0x80) >> 7) & 1) << N_SHIFT) |
-		 (szp_flags[(W & 7) ^ B] & P_FLAG) |
-		 (szp_flags[B] & ~P_FLAG));
+            F = ((WH << H_SHIFT) | (WH << C_SHIFT) |
+                 ((((res & 0x80) >> 7) & 1) << N_SHIFT) |
+                 (szp_flags[(W & 7) ^ B] & P_FLAG) |
+                 (szp_flags[B] & ~P_FLAG));
             t += 8;
             break;
 
           case 0xa3:		/* OUTI */
-            res = memrdr((H << 8) | L);
-            W = ((H << 8) | L) + 1;
-            H = W >> 8;
-            L = W & 0xff;
+            res = memrdr(HL++);
             io_out(C, --B, res);
             W = L;
             goto finish_ioid;
 
           case 0xa8:		/* LDD */
-            memwrt((D << 8) | E, memrdr((H << 8) | L));
-            W = ((D << 8) | E) - 1;
-            D = W >> 8;
-            E = W & 0xff;
-            W = ((H << 8) | L) - 1;
-            H = W >> 8;
-            L = W & 0xff;
+            memwrt(DE--, memrdr(HL--));
             goto finish_ldid;
 
           case 0xa9:		/* CPD */
-            P = memrdr((H << 8) | L);
-            W = ((H << 8) | L) - 1;
-            H = W >> 8;
-            L = W & 0xff;
+            P = memrdr(HL--);
             goto finish_cpid;
 
           case 0xaa:		/* IND */
             res = io_in(C, B--);
-            memwrt((H << 8) | L, res);
-            W = ((H << 8) | L) - 1;
-            H = W >> 8;
-            L = W & 0xff;
+            memwrt(HL--, res);
             W = (C - 1) & 0xff;
             goto finish_ioid;
 
           case 0xab:		/* OUTD */
-            res = memrdr((H << 8) | L);
-            W = ((H << 8) | L) - 1;
-            H = W >> 8;
-            L = W & 0xff;
+            res = memrdr(HL--);
             io_out(C, --B, res);
             W = L;
             goto finish_ioid;
 
 #ifdef FAST_BLOCK
           case 0xb0:		/* LDIR */
-            W = (B << 8) | C;
-            d = (D << 8) | E;
-            s = (H << 8) | L;
+            W = BC;
+            d = DE;
+            s = HL;
             tl = -13L;
             R -= 2;
             do {
@@ -2169,19 +2152,17 @@ finish_ioid:
               R += 2;
             } while (--W);
 finish_ldidr:
-            B = C = 0;
-            D = d >> 8;
-            E = d & 0xff;
-            H = s >> 8;
-            L = s & 0xff;
+            BC = 0;
+            DE = d;
+            HL = s;
             F &= ~(H_FLAG | N_FLAG | P_FLAG);
             /* S_FLAG, Z_FLAG, and C_FLAG unchanged */
             tstates += tl;
             break;
 
           case 0xb1:		/* CPIR */
-            W = (B << 8) | C;
-            s = (H << 8) | L;
+            W = BC;
+            s = HL;
             tl = -13L;
             R -= 2;
             do {
@@ -2191,22 +2172,20 @@ finish_ldidr:
               R += 2;
             } while (--W && res);
 finish_cpidr:
-            B = W >> 8;
-            C = W & 0xff;
-            H = s >> 8;
-            L = s & 0xff;
+            BC = W;
+            HL = s;
             cout = (~A & P) | ((~A | P) & res);
             F = ((F & C_FLAG) |
-		 (((cout >> 3) & 1) << H_SHIFT) |
-		 N_FLAG |
-		 ((W != 0) << P_SHIFT) |
-		 (szp_flags[res] & ~P_FLAG));
+                 (((cout >> 3) & 1) << H_SHIFT) |
+                 N_FLAG |
+                 ((W != 0) << P_SHIFT) |
+                 (szp_flags[res] & ~P_FLAG));
             /* C_FLAG unchanged */
             tstates += tl;
             break;
 
           case 0xb2:		/* INIR */
-            s = (H << 8) | L;
+            s = HL;
             R -= 2;
             tl = -13L;
             do {
@@ -2217,19 +2196,18 @@ finish_cpidr:
             } while (B);
             W = (C + 1) & 0xff;
 finish_ioidr:
-            H = s >> 8;
-            L = s & 0xff;
+            HL = s;
             W += res;
-            F = (((W >> 8) << H_SHIFT) | ((W >> 8) << C_SHIFT) |
-		 ((((res & 0x80) >> 7) & 1) << N_SHIFT) |
-		 (szp_flags[W & 7] & P_FLAG) |
-		 Z_FLAG);
+            F = ((WH << H_SHIFT) | (WH << C_SHIFT) |
+                 ((((res & 0x80) >> 7) & 1) << N_SHIFT) |
+                 (szp_flags[W & 7] & P_FLAG) |
+                 Z_FLAG);
             /* S_FLAG cleared */
             tstates += tl;
             break;
 
           case 0xb3:		/* OTIR */
-            s = (H << 8) | L;
+            s = HL;
             tl = -13L;
             R -= 2;
             do {
@@ -2242,9 +2220,9 @@ finish_ioidr:
             goto finish_ioidr;
 
           case 0xb8:		/* LDDR */
-            W = (B << 8) | C;
-            d = (D << 8) | E;
-            s = (H << 8) | L;
+            W = BC;
+            d = DE;
+            s = HL;
             tl = -13L;
             R -= 2;
             do {
@@ -2255,8 +2233,8 @@ finish_ioidr:
             goto finish_ldidr;
 
           case 0xb9:		/* CPDR */
-            W = (B << 8) | C;
-            s = (H << 8) | L;
+            W = BC;
+            s = HL;
             tl = -13L;
             R -= 2;
             do {
@@ -2268,7 +2246,7 @@ finish_ioidr:
             goto finish_cpidr;
 
           case 0xba:		/* INDR */
-            s = (H << 8) | L;
+            s = HL;
             tl = -13L;
             R -= 2;
             do {
@@ -2281,7 +2259,7 @@ finish_ioidr:
             goto finish_ioidr;
 
           case 0xbb:		/* OTDR */
-            s = (H << 8) | L;
+            s = HL;
             tl = -13L;
             R -= 2;
             do {
@@ -2294,111 +2272,77 @@ finish_ioidr:
             goto finish_ioidr;
 #else  /* !FAST_BLOCK */
           case 0xb0:		/* LDIR */
-            memwrt((D << 8) | E, memrdr((H << 8) | L));
-            W = ((D << 8) | E) + 1;
-            D = W >> 8;
-            E = W & 0xff;
-            W = ((H << 8) | L) + 1;
-            H = W >> 8;
-            L = W & 0xff;
+            memwrt(DE++, memrdr(HL++));
 finish_ldidr:
-            W = ((B << 8) | C) - 1;
-            B = W >> 8;
-            C = W & 0xff;
+            BC--;
             F = ((F & ~(H_FLAG | N_FLAG | P_FLAG)) |
-		 (((B | C) != 0) << P_SHIFT));
+                 ((BC != 0) << P_SHIFT));
             /* S_FLAG, Z_FLAG, and C_FLAG unchanged */
             t += 8;
             if (F & P_FLAG) {
               t += 5;
-              PC8 -= 2;
+              PC -= 2;
             }
             break;
 
           case 0xb1:		/* CPIR */
-            P = memrdr((H << 8) | L);
-            W = ((H << 8) | L) + 1;
-            H = W >> 8;
-            L = W & 0xff;
+            P = memrdr(HL++);
 finish_cpidr:
-            W = ((B << 8) | C) - 1;
-            B = W >> 8;
-            C = W & 0xff;
+            BC--;
             res = A - P;
             cout = (~A & P) | ((~A | P) & res);
             F = ((F & C_FLAG) |
-		 (((cout >> 3) & 1) << H_SHIFT) |
-		 N_FLAG |
-		 (((B | C) != 0) << P_SHIFT) |
-		 (szp_flags[res] & ~P_FLAG));
+                 (((cout >> 3) & 1) << H_SHIFT) |
+                 N_FLAG |
+                 ((BC != 0) << P_SHIFT) |
+                 (szp_flags[res] & ~P_FLAG));
             /* C_FLAG unchanged */
             t += 8;
             if ((F & (P_FLAG | Z_FLAG)) == P_FLAG) {
               t += 5;
-              PC8 -= 2;
+              PC -= 2;
             }
             break;
 
           case 0xb2:		/* INIR */
             res = io_in(C, B--);
-            memwrt((H << 8) | L, res);
-            W = ((H << 8) | L) + 1;
-            H = W >> 8;
-            L = W & 0xff;
+            memwrt(HL++, res);
             W = (C + 1) & 0xff;
 finish_ioidr:
             W += res;
-            F = (((W >> 8) << H_SHIFT) | ((W >> 8) << C_SHIFT) |
-		 ((((res & 0x80) >> 7) & 1) << N_SHIFT) |
-		 (szp_flags[(W & 7) ^ B] & P_FLAG) |
-		 (szp_flags[B] & ~P_FLAG));
+            F = ((WH << H_SHIFT) | (WH << C_SHIFT) |
+                 ((((res & 0x80) >> 7) & 1) << N_SHIFT) |
+                 (szp_flags[(W & 7) ^ B] & P_FLAG) |
+                 (szp_flags[B] & ~P_FLAG));
             t += 8;
             if (!(F & Z_FLAG)) {
               t += 5;
-              PC8 -= 2;
+              PC -= 2;
             }
             break;
 
           case 0xb3:		/* OTIR */
-            res = memrdr((H << 8) | L);
-            W = ((H << 8) | L) + 1;
-            H = W >> 8;
-            L = W & 0xff;
+            res = memrdr(HL++);
             io_out(C, --B, res);
             W = L;
             goto finish_ioidr;
 
           case 0xb8:		/* LDDR */
-            memwrt((D << 8) | E, memrdr((H << 8) | L));
-            W = ((D << 8) | E) - 1;
-            D = W >> 8;
-            E = W & 0xff;
-            W = ((H << 8) | L) - 1;
-            H = W >> 8;
-            L = W & 0xff;
+            memwrt(DE--, memrdr(HL--));
             goto finish_ldidr;
 
           case 0xb9:		/* CPDR */
-            P = memrdr((H << 8) | L);
-            W = ((H << 8) | L) - 1;
-            H = W >> 8;
-            L = W & 0xff;
+            P = memrdr(HL--);
             goto finish_cpidr;
 
           case 0xba:		/* INDR */
             res = io_in(C, B--);
-            memwrt((H << 8) | L, res);
-            W = ((H << 8) | L) - 1;
-            H = W >> 8;
-            L = W & 0xff;
+            memwrt(HL--, res);
             W = (C - 1) & 0xff;
             goto finish_ioidr;
 
           case 0xbb:		/* OTDR */
-            res = memrdr((H << 8) | L);
-            W = ((H << 8) | L) - 1;
-            H = W >> 8;
-            L = W & 0xff;
+            res = memrdr(HL--);
             io_out(C, --B, res);
             W = L;
             goto finish_ioidr;
@@ -2408,11 +2352,11 @@ finish_ioidr:
             break;
         }
         curr_ir = IR_HL;
-        IR = (H << 8) | L;
+        IR = HL;
         break;
 
       case 0xee:		/* XOR n */
-        P = memrdr(PC8++);
+        P = memrdr(PC++);
         t += 3;
         goto finish_xor;
 
@@ -2425,8 +2369,8 @@ finish_ioidr:
         goto finish_retc;
 
       case 0xf1:		/* POP AF */
-        F = memrdr(SP8++);
-        A = memrdr(SP8++);
+        F = memrdr(SP++);
+        A = memrdr(SP++);
         t += 6;
         break;
 
@@ -2443,13 +2387,13 @@ finish_ioidr:
         goto finish_callc;
 
       case 0xf5:		/* PUSH AF */
-        memwrt(--SP8, A);
-        memwrt(--SP8, F);
+        memwrt(--SP, A);
+        memwrt(--SP, F);
         t += 7;
         break;
 
       case 0xf6:		/* OR n */
-        P = memrdr(PC8++);
+        P = memrdr(PC++);
         t += 3;
         goto finish_or;
 
@@ -2462,7 +2406,7 @@ finish_ioidr:
         goto finish_retc;
 
       case 0xf9:		/* LD SP,ir */
-        SP8 = IR;
+        SP = IR;
         t += 2;
         break;
 
@@ -2487,7 +2431,7 @@ finish_ioidr:
         goto next_opcode;
 
       case 0xfe:		/* CP n */
-        P = memrdr(PC8++);
+        P = memrdr(PC++);
         t += 3;
         goto finish_cp;
 
@@ -2496,10 +2440,9 @@ finish_ioidr:
         goto finish_call;
     }
 
-    if (curr_ir == IR_HL) {
-      H = IR >> 8;
-      L = IR & 0xff;
-    } else if (curr_ir == IR_IX)
+    if (curr_ir == IR_HL)
+      HL = IR;
+    else if (curr_ir == IR_IX)
       IX = IR;
     else
       IY = IR;
@@ -2508,34 +2451,52 @@ finish_ioidr:
 
   } while (State == Running);
 
+  *cpu_state = cpu_regs;
+
+#undef W
+#undef WH
+#undef WL
+
+#undef IR
+#undef IRH
+#undef IRL
+
 #undef IR_HL
 #undef IR_IX
 #undef IR_IY
 
-  cpu_state->A = A;
-  cpu_state->B = B;
-  cpu_state->C = C;
-  cpu_state->D = D;
-  cpu_state->E = E;
-  cpu_state->H = H;
-  cpu_state->L = L;
-  cpu_state->F = F;
-  cpu_state->IFF = IFF;
-  cpu_state->A_ = A_;
-  cpu_state->B_ = B_;
-  cpu_state->C_ = C_;
-  cpu_state->D_ = D_;
-  cpu_state->E_ = E_;
-  cpu_state->H_ = H_;
-  cpu_state->L_ = L_;
-  cpu_state->F_ = F_;
-  cpu_state->I = I;
-  cpu_state->R = R;
-  cpu_state->R_ = R_;
-  cpu_state->IX = IX;
-  cpu_state->IY = IY;
-  cpu_state->PC8 = PC8;
-  cpu_state->SP8 = SP8;
+#undef AF
+#undef A
+#undef F
+#undef BC
+#undef B
+#undef C
+#undef DE
+#undef D
+#undef E
+#undef HL
+#undef H
+#undef L
+#undef SP
+#undef SPH
+#undef SPL
+#undef PC
+#undef PCH
+#undef PCL
+#undef AF_
+#undef BC_
+#undef DE_
+#undef HL_
+#undef IX
+#undef IY
+#undef I
+#undef R
+#undef R_
+#undef IFF
+
+#pragma pop_macro("F")
+#pragma pop_macro("SP")
+#pragma pop_macro("PC")
 }
 
 // interrupt handler for break switch, stops CPU
@@ -2638,29 +2599,29 @@ void loop()
   
   // print register dump
   Serial.println(F("PC\tA\tSZHPC\tB:C\tD:E\tH:L\tSP"));
-  Serial.print(cpu_state.PC8, HEX);
+  Serial.print(cpu_state.pc.w, HEX);
   Serial.print(F("\t"));
-  Serial.print(cpu_state.A, HEX);
+  Serial.print(cpu_state.af.h, HEX);
   Serial.print(F("\t"));
-  Serial.print(cpu_state.F & S_FLAG ? 1 : 0, DEC);
-  Serial.print(cpu_state.F & Z_FLAG ? 1 : 0, DEC);
-  Serial.print(cpu_state.F & H_FLAG ? 1 : 0, DEC);
-  Serial.print(cpu_state.F & P_FLAG ? 1 : 0, DEC);
-  Serial.print(cpu_state.F & C_FLAG ? 1 : 0, DEC);
+  Serial.print(cpu_state.af.l & S_FLAG ? 1 : 0, DEC);
+  Serial.print(cpu_state.af.l & Z_FLAG ? 1 : 0, DEC);
+  Serial.print(cpu_state.af.l & H_FLAG ? 1 : 0, DEC);
+  Serial.print(cpu_state.af.l & P_FLAG ? 1 : 0, DEC);
+  Serial.print(cpu_state.af.l & C_FLAG ? 1 : 0, DEC);
   Serial.print(F("\t"));
-  Serial.print(cpu_state.B, HEX);
+  Serial.print(cpu_state.bc.h, HEX);
   Serial.print(F(":"));
-  Serial.print(cpu_state.C, HEX);
+  Serial.print(cpu_state.bc.l, HEX);
   Serial.print(F("\t"));
-  Serial.print(cpu_state.D, HEX);
+  Serial.print(cpu_state.de.h, HEX);
   Serial.print(F(":"));
-  Serial.print(cpu_state.E, HEX);
+  Serial.print(cpu_state.de.l, HEX);
   Serial.print(F("\t"));
-  Serial.print(cpu_state.H, HEX);
+  Serial.print(cpu_state.hl.h, HEX);
   Serial.print(F(":"));
-  Serial.print(cpu_state.L, HEX);
+  Serial.print(cpu_state.hl.l, HEX);
   Serial.print(F("\t"));
-  Serial.print(cpu_state.SP8, HEX);
+  Serial.print(cpu_state.sp.w, HEX);
   Serial.println();
 
   // print some execution statistics


### PR DESCRIPTION
And some other tweaks.

Saved 1770 bytes for Z80, but only 172 for the 8080.

Also learned about "push_macro/pop_macro" pragmas. Allows usage of F, SP, and PC macros in cpu_*.